### PR TITLE
Change VarInts to i32 to represent actual data type

### DIFF
--- a/src/game_state/player.rs
+++ b/src/game_state/player.rs
@@ -79,10 +79,11 @@ pub fn start_player_state(
                 let mut player_clone = player.clone();
                 let position_delta =
                     PositionDelta::new(player_clone.position, msg.new_position.clone());
+                println!("ayy");
                 broadcast_packet!(
                     messenger,
                     Packet::EntityLookAndMove(EntityLookAndMove {
-                        entity_id: player_clone.conn_id.as_u128() as u64,
+                        entity_id: player_clone.conn_id.as_u128() as i32,
                         delta_x: position_delta.x,
                         delta_y: position_delta.y,
                         delta_z: position_delta.z,
@@ -117,7 +118,7 @@ pub fn start_player_state(
                         messenger,
                         msg.conn_id,
                         Packet::SpawnPlayer(SpawnPlayer {
-                            entity_id: player.conn_id.as_u128() as u64,
+                            entity_id: player.conn_id.as_u128() as i32,
                             uuid: player_clone.uuid.as_u128(),
                             x: player_clone.position.x,
                             y: player_clone.position.y,

--- a/src/initiation_protocols/border_cross_login_init.rs
+++ b/src/initiation_protocols/border_cross_login_init.rs
@@ -4,6 +4,6 @@ use super::packet;
 use super::packet::{read, write, Packet};
 
 // Called by the server when a new player is walking in its map
-pub fn init_border_cross_login(p: Packet, state: &mut u64) {
-    println!("TODO");
+pub fn init_border_cross_login(p: Packet, state: &mut i32) {
+    unimplemented!("TODO");
 }

--- a/src/initiation_protocols/handshake_init.rs
+++ b/src/initiation_protocols/handshake_init.rs
@@ -1,7 +1,7 @@
 use super::packet::Packet;
 
 // Called upon handshake
-pub fn init_handshake(p: Packet, state: &mut u64) {
+pub fn init_handshake(p: Packet, state: &mut i32) {
     println!("Handshake packet: {:?}", p);
 
     *state = match p.clone() {

--- a/src/initiation_protocols/in_peer_sub_init.rs
+++ b/src/initiation_protocols/in_peer_sub_init.rs
@@ -4,6 +4,6 @@ use super::packet;
 use super::packet::{read, write, Packet};
 
 // Called when a server requests a peer subscription
-pub fn init_incoming_peer_sub(p: Packet, state: &mut u64) {
-    println!("TODO");
+pub fn init_incoming_peer_sub(p: Packet, state: &mut i32) {
+    unimplemented!()
 }

--- a/src/initiation_protocols/login_init.rs
+++ b/src/initiation_protocols/login_init.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 // Called upon user login
 pub fn init_login(
     p: Packet,
-    state: &mut u64,
+    state: &mut i32,
     conn_id: Uuid,
     messenger: Sender<MessengerOperations>,
     player_state: Sender<PlayerStateOperations>,

--- a/src/initiation_protocols/out_peer_sub_init.rs
+++ b/src/initiation_protocols/out_peer_sub_init.rs
@@ -4,6 +4,6 @@ use super::packet;
 use super::packet::{read, write, Packet};
 
 // Called when requesting a peer subscription to another server
-pub fn init_outgoing_peer_sub(p: Packet, state: &mut u64) {
-    println!("TODO");
+pub fn init_outgoing_peer_sub(p: Packet, state: &mut i32) {
+    unimplemented!();
 }

--- a/src/packet_macros.rs
+++ b/src/packet_macros.rs
@@ -10,7 +10,7 @@ macro_rules! packet_boilerplate {
             $($name($name)),*
         }
 
-        pub fn read<S: MinecraftProtocolReader + Read>(stream: &mut S, state: u64, length: u64) -> Packet {
+        pub fn read<S: MinecraftProtocolReader + Read>(stream: &mut S, state: i32, length: i32) -> Packet {
             //Read the entire packet into a vector first
             let vec: Vec<u8> = stream
                 .bytes()
@@ -51,7 +51,7 @@ macro_rules! packet_boilerplate {
 
             //Write the length into a vector
             cursor = Cursor::new(Vec::new());
-            write_var_int(&mut cursor, size as u64);
+            write_var_int(&mut cursor, size as i32);
 
             //combine the length vector with the sizing vector to get
             //the full byte vector of the packet
@@ -82,7 +82,7 @@ macro_rules! packet {
         #[derive(Debug, Clone)]
         pub struct $name { $(pub $fieldname: mc_to_rust_datatype!($datatype)),* }
         impl $name {
-            const ID: u64 = $id;
+            const ID: i32 = $id;
             pub fn new<S: MinecraftProtocolReader>(stream: &mut S) -> $name {
                 $name { $( $fieldname: read_packet_field!(stream, $datatype) ),* }
             }
@@ -95,7 +95,7 @@ macro_rules! packet {
 
 macro_rules! mc_to_rust_datatype {
     (VarInt) => {
-        u64
+        i32
     };
     (UShort) => {
         u16

--- a/src/packet_router.rs
+++ b/src/packet_router.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 // Routes the packet to the corresponding service according to the connection state
 pub fn route_packet(
     p: Packet,
-    state: &mut u64,
+    state: &mut i32,
     conn_id: Uuid,
     messenger: Sender<MessengerOperations>,
     player_state: Sender<PlayerStateOperations>,
@@ -40,7 +40,7 @@ enum Status {
 }
 
 impl Status {
-    fn value(status: u64) -> Status {
+    fn value(status: i32) -> Status {
         match status {
             0 => Status::Handshake,
             1 => Status::ClientPing,

--- a/src/server.rs
+++ b/src/server.rs
@@ -32,7 +32,7 @@ pub fn handle_connection(
     messenger: Sender<MessengerOperations>,
     player_state: Sender<PlayerStateOperations>,
 ) {
-    let mut state = 0;
+    let mut state = 0 as i32;
     let conn_id = Uuid::new_v4();
     let stream_clone = stream.try_clone().unwrap();
     messenger


### PR DESCRIPTION
We had the wrong datatype initially, so when we swapped to uuids for player connection ids entity ids broke. This fixes it