### PR TITLE
Add the concept of translation data into packet service

### DIFF
--- a/src/initiation_protocols/border_cross_login_init.rs
+++ b/src/initiation_protocols/border_cross_login_init.rs
@@ -4,6 +4,6 @@ use super::packet;
 use super::packet::{read, write, Packet};
 
 // Called by the server when a new player is walking in its map
-pub fn init_border_cross_login(p: Packet, state: &mut i32) {
+pub fn init_border_cross_login(p: Packet) {
     unimplemented!("TODO");
 }

--- a/src/initiation_protocols/handshake_init.rs
+++ b/src/initiation_protocols/handshake_init.rs
@@ -1,14 +1,9 @@
 use super::packet::Packet;
 
 // Called upon handshake
-pub fn init_handshake(p: Packet, state: &mut i32) {
-    println!("Handshake packet: {:?}", p);
-
-    *state = match p.clone() {
+pub fn init_handshake(p: Packet) -> i32 {
+    match p.clone() {
         Packet::Handshake(handshake) => handshake.next_state,
-        _ => {
-            println!("Invalid packet (handshake)");
-            *state
-        }
-    };
+        _ => panic!("Invalid packet (handshake)"),
+    }
 }

--- a/src/initiation_protocols/in_peer_sub_init.rs
+++ b/src/initiation_protocols/in_peer_sub_init.rs
@@ -4,6 +4,6 @@ use super::packet;
 use super::packet::{read, write, Packet};
 
 // Called when a server requests a peer subscription
-pub fn init_incoming_peer_sub(p: Packet, state: &mut i32) {
+pub fn init_incoming_peer_sub(p: Packet) {
     unimplemented!()
 }

--- a/src/initiation_protocols/login_init.rs
+++ b/src/initiation_protocols/login_init.rs
@@ -11,7 +11,6 @@ use uuid::Uuid;
 // Called upon user login
 pub fn init_login(
     p: Packet,
-    state: &mut i32,
     conn_id: Uuid,
     messenger: Sender<MessengerOperations>,
     player_state: Sender<PlayerStateOperations>,
@@ -19,7 +18,6 @@ pub fn init_login(
     println!("Login protocol initiated :{:?}", p);
     match p.clone() {
         Packet::LoginStart(login_start) => {
-            *state = 3;
             confirm_login(conn_id, messenger, login_start, player_state);
         }
         _ => {

--- a/src/initiation_protocols/out_peer_sub_init.rs
+++ b/src/initiation_protocols/out_peer_sub_init.rs
@@ -4,6 +4,6 @@ use super::packet;
 use super::packet::{read, write, Packet};
 
 // Called when requesting a peer subscription to another server
-pub fn init_outgoing_peer_sub(p: Packet, state: &mut i32) {
+pub fn init_outgoing_peer_sub(p: Packet) {
     unimplemented!();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,13 @@
 mod messenger;
 #[macro_use]
 mod packet_macros;
-mod packet_processor;
 mod game_state;
 mod gameplay_router;
 mod initiation_protocols;
 mod keep_alive;
 mod minecraft_protocol;
 mod packet;
+mod packet_processor;
 mod packet_router;
 mod peer_conn_protocol;
 mod server;
@@ -36,11 +36,20 @@ fn main() {
 
     let messenger_clone = messenger_sender.clone();
     let player_state_clone = player_state_sender.clone();
-    thread::spawn(move || start_inbound(inbound_packet_processor_receiver, messenger_clone, player_state_clone));
+    thread::spawn(move || {
+        start_inbound(
+            inbound_packet_processor_receiver,
+            messenger_clone,
+            player_state_clone,
+        )
+    });
 
     let peer_ip_addr = String::from("127.0.0.1");
     let peer_port = env::var("PEER_PORT").unwrap().parse::<u16>().unwrap();
     peer_conn_protocol::send_p2p_handshake(peer_ip_addr, peer_port, messenger_sender.clone()).ok();
 
-    server::listen(inbound_packet_processor_sender, messenger_sender.clone());
+    server::listen(
+        inbound_packet_processor_sender.clone(),
+        messenger_sender.clone(),
+    );
 }

--- a/src/minecraft_protocol.rs
+++ b/src/minecraft_protocol.rs
@@ -119,7 +119,8 @@ impl<T: Read> MinecraftProtocolReader for T {
         let size = self.read_var_int();
 
         let mut buffer = vec![0; size as usize];
-        self.read_exact(&mut buffer).unwrap();
+        self.read_exact(&mut buffer)
+            .expect("didn't find enough characters");
         String::from_utf8(buffer).unwrap()
     }
 

--- a/src/packet_processor.rs
+++ b/src/packet_processor.rs
@@ -1,42 +1,74 @@
-use super::game_state::player::{PlayerStateOperations};
-use super::packet_router;
-use super::messenger::{MessengerOperations};
+use super::game_state::player::PlayerStateOperations;
+use super::messenger::MessengerOperations;
 use super::packet::read;
+use super::packet_router;
 use std::collections::HashMap;
-use std::io::{Cursor};
+use std::io::Cursor;
 use std::sync::mpsc::{Receiver, Sender};
 use uuid::Uuid;
 
 pub enum PacketProcessorOperations {
-    Inbound(InboundPacketMessage)
+    Inbound(InboundPacketMessage),
+}
+
+pub enum TranslationUpdates {
+    State(i32),
+    NoChange,
 }
 
 #[derive(Debug)]
 pub struct InboundPacketMessage {
     pub conn_id: Uuid,
-    pub cursor: Cursor<Vec<u8>>
+    pub cursor: Cursor<Vec<u8>>,
+}
+
+struct TranslationInfo {
+    pub state: i32,
+    pub map: Option<Map>,
+}
+
+struct Map {
+    pub x_origin: i32,
+    pub y_origin: i32,
+}
+
+impl TranslationInfo {
+    pub fn new() -> TranslationInfo {
+        TranslationInfo {
+            state: 0,
+            map: None,
+        }
+    }
+
+    pub fn update(&mut self, params: TranslationUpdates) {
+        if let TranslationUpdates::State(state) = params {
+            self.state = state;
+        }
+    }
 }
 
 pub fn start_inbound(
     receiver: Receiver<PacketProcessorOperations>,
     messenger: Sender<MessengerOperations>,
-    player_state: Sender<PlayerStateOperations>
+    player_state: Sender<PlayerStateOperations>,
 ) {
-    let mut state_map = HashMap::<Uuid, i32>::new();
+    let mut translation_data = HashMap::<Uuid, TranslationInfo>::new();
 
     while let Ok(msg) = receiver.recv() {
         match msg {
             PacketProcessorOperations::Inbound(msg) => {
-                let mut state = state_map.entry(msg.conn_id).or_insert(0);
+                let translation_data = translation_data
+                    .entry(msg.conn_id)
+                    .or_insert_with(TranslationInfo::new);
 
-                let packet = read(&mut msg.cursor.clone(), *state);
-                packet_router::route_packet(
+                let packet = read(&mut msg.cursor.clone(), translation_data.state);
+                translation_data.update(packet_router::route_packet(
                     packet,
-                    &mut state,
+                    translation_data.state,
                     msg.conn_id,
                     messenger.clone(),
                     player_state.clone(),
-                );
+                ));
             }
         }
     }


### PR DESCRIPTION
We no longer need to pass state around- the call to packet router always returns a (potentially empty) update to the translation information (state is now considered translation information)

