### PR TITLE
Add patchwork state, use it to perform handshake

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -1,4 +1,6 @@
+pub mod patchwork;
 pub mod player;
 
 use super::messenger;
 use super::packet;
+use super::server;

--- a/src/game_state/patchwork.rs
+++ b/src/game_state/patchwork.rs
@@ -1,0 +1,135 @@
+use super::messenger::{NewConnectionMessage, BroadcastPacketMessage, MessengerOperations, SendPacketMessage};
+use super::server;
+use super::packet::{Packet, Handshake};
+use std::collections::HashMap;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::Sender;
+use uuid::Uuid;
+
+pub enum PatchworkStateOperations {
+    New(NewMapMessage),
+    Report(ReportMessage),
+}
+
+#[derive(Debug)]
+pub struct NewMapMessage {
+    pub peer: Peer,
+}
+
+#[derive(Debug)]
+pub struct ReportMessage {
+    pub conn_id: Uuid,
+}
+
+#[derive(Debug, Clone)]
+struct Patchwork {
+    pub maps: Vec<Map>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Peer {
+    pub port: u16,
+    pub address: String,
+}
+
+impl Patchwork {
+    pub fn new() -> Patchwork {
+        Patchwork {
+            maps: Vec::<Map>::new(),
+        }
+    }
+
+    pub fn add_map(&mut self, peer: Peer) -> Map {
+        let map = Map {
+            position: self.next_position(),
+            peer,
+            entity_id_block: self.next_entity_id_block(),
+        };
+        self.maps.push(map.clone());
+        println!("patchwork maps {:?}", self.maps);
+        map
+    }
+
+    // get the next block of size 1000 entity ids assigned to this map
+    fn next_entity_id_block(&self) -> i32 {
+        (self.maps.len() + 1) as i32
+    }
+
+    // For now, just line up all the maps in a row
+    fn next_position(&self) -> Position {
+        let len = self.maps.len() as i32;
+        Position { x: len + 1, z: 0 }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Map {
+    pub position: Position,
+    pub entity_id_block: i32,
+    pub peer: Peer,
+}
+
+impl Map {
+    fn connect(self, messenger: Sender<MessengerOperations>) {
+        let conn_id = Uuid::new_v4();
+        if let Ok(stream) = server::new_connection(self.peer.address.clone(), self.peer.port) {
+            messenger
+                .send(MessengerOperations::New(NewConnectionMessage {
+                    conn_id,
+                    socket: stream.try_clone().unwrap(),
+                }))
+                .unwrap();
+
+            send_packet!(
+                messenger,
+                conn_id,
+                Packet::Handshake(Handshake {
+                    protocol_version: 404,
+                    server_address: self.peer.address.clone(),
+                    server_port: self.peer.port,
+                    next_state: 6,
+                })
+            )
+            .unwrap();
+
+            send_packet!(
+                messenger,
+                conn_id,
+                Packet::Handshake(Handshake {
+                    protocol_version: 404,
+                    server_address: self.peer.address.clone(),
+                    server_port: self.peer.port,
+                    next_state: 6,
+                })
+            )
+            .unwrap();
+        };
+    }
+}
+
+//This probably belongs at an entity level, but since we don't have a real concept of entities yet
+//this'll do
+//Ignoring angle since we haven't implemented that datatype just yet
+#[derive(Debug, Clone)]
+pub struct Position {
+    pub x: i32,
+    pub z: i32,
+}
+
+pub fn start_patchwork_state(
+    receiver: Receiver<PatchworkStateOperations>,
+    messenger: Sender<MessengerOperations>,
+) {
+    let mut patchwork = Patchwork::new();
+
+    while let Ok(msg) = receiver.recv() {
+        match msg {
+            PatchworkStateOperations::New(msg) => {
+                patchwork.add_map(msg.peer).connect(messenger.clone());
+            }
+            PatchworkStateOperations::Report(msg) => {
+                unimplemented!("Don't know how to report this yet");
+            }
+        }
+    }
+}

--- a/src/initiation_protocols/out_peer_sub_init.rs
+++ b/src/initiation_protocols/out_peer_sub_init.rs
@@ -5,5 +5,5 @@ use super::packet::{read, write, Packet};
 
 // Called when requesting a peer subscription to another server
 pub fn init_outgoing_peer_sub(p: Packet) {
-    unimplemented!();
+    println!("I would now start sending my peer event packets");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod packet_processor;
 mod packet_router;
 mod peer_conn_protocol;
 mod server;
+use game_state::patchwork::start_patchwork_state;
 use game_state::player::start_player_state;
 use keep_alive::start_keep_alive;
 use messenger::start_messenger;
@@ -25,11 +26,15 @@ fn main() {
     let (keep_alive_sender, keep_alive_receiver) = channel();
     let (inbound_packet_processor_sender, inbound_packet_processor_receiver) = channel();
     let (player_state_sender, player_state_receiver) = channel();
+    let (patchwork_state_sender, patchwork_state_receiver) = channel();
 
     thread::spawn(move || start_messenger(messenger_receiver, keep_alive_sender));
 
     let messenger_clone = messenger_sender.clone();
     thread::spawn(move || start_player_state(player_state_receiver, messenger_clone));
+
+    let messenger_clone = messenger_sender.clone();
+    thread::spawn(move || start_patchwork_state(patchwork_state_receiver, messenger_clone));
 
     let messenger_clone = messenger_sender.clone();
     thread::spawn(move || start_keep_alive(keep_alive_receiver, messenger_clone));
@@ -46,7 +51,12 @@ fn main() {
 
     let peer_ip_addr = String::from("127.0.0.1");
     let peer_port = env::var("PEER_PORT").unwrap().parse::<u16>().unwrap();
-    peer_conn_protocol::send_p2p_handshake(peer_ip_addr, peer_port, messenger_sender.clone()).ok();
+    peer_conn_protocol::send_p2p_handshake(
+        peer_ip_addr,
+        peer_port,
+        messenger_sender.clone(),
+        patchwork_state_sender.clone(),
+    );
 
     server::listen(
         inbound_packet_processor_sender.clone(),

--- a/src/peer_conn_protocol.rs
+++ b/src/peer_conn_protocol.rs
@@ -1,3 +1,4 @@
+use super::game_state::patchwork::{NewMapMessage, PatchworkStateOperations, Peer};
 use super::messenger::{MessengerOperations, NewConnectionMessage, SendPacketMessage};
 use super::packet::{Handshake, Packet};
 use super::server;
@@ -10,27 +11,12 @@ pub fn send_p2p_handshake(
     peer_address: String,
     peer_port: u16,
     messenger: Sender<MessengerOperations>,
-) -> Result<Uuid, io::Error> {
-    let conn_id = Uuid::new_v4();
-    let stream = server::new_connection(peer_address.clone(), peer_port)?;
-    messenger
-        .send(MessengerOperations::New(NewConnectionMessage {
-            conn_id,
-            socket: stream.try_clone().unwrap(),
-        }))
-        .unwrap();
-
-    send_packet!(
-        messenger,
-        conn_id,
-        Packet::Handshake(Handshake {
-            protocol_version: 404,
-            server_address: peer_address.clone(),
-            server_port: peer_port,
-            next_state: 6,
-        })
-    )
-    .unwrap();
-
-    Ok(Uuid::new_v4())
+    patchwork_state: Sender<PatchworkStateOperations>,
+) {
+    patchwork_state.send(PatchworkStateOperations::New(NewMapMessage {
+        peer: Peer {
+            port: peer_port,
+            address: peer_address,
+        },
+    }));
 }


### PR DESCRIPTION
Adding a Patchwork State in the same model of player state. This will hold a list of maps and be responsible for both creating the connection to get event packets, and will also be in charge of getting a report of external servers for new players (future PR)

(kinda messy but wanted a commit b4 going too far)