### PR TITLE
Players can see each other move on different servers.

### DIFF
--- a/src/initiation_protocols/in_peer_sub_init.rs
+++ b/src/initiation_protocols/in_peer_sub_init.rs
@@ -9,6 +9,6 @@ use std::sync::mpsc::Sender;
 use uuid::Uuid;
 
 // needs to be renamed, just didn't want to make another one of these
-pub fn init_incoming_peer_sub(p: Packet, conn_id: Uuid, messenger: Sender<MessengerOperations>) {
-    broadcast_packet!(messenger, p).unwrap();
+pub fn init_incoming_peer_sub(packet: Packet, conn_id: Uuid, messenger: Sender<MessengerOperations>) {
+    broadcast_packet!(messenger, packet, None, false).unwrap();
 }

--- a/src/initiation_protocols/out_peer_sub_init.rs
+++ b/src/initiation_protocols/out_peer_sub_init.rs
@@ -4,6 +4,7 @@ use super::game_state::block;
 use super::game_state::block::BlockStateOperations;
 use super::game_state::player;
 use super::game_state::player::{NewPlayerMessage, Player, PlayerStateOperations, Position};
+use super::messenger::{MessengerOperations, SendPacketMessage, SubscribeMessage};
 use super::packet::{EntityLookAndMove, Packet, PlayerInfo, SpawnPlayer};
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
@@ -12,9 +13,18 @@ use uuid::Uuid;
 pub fn init_outgoing_peer_sub(
     p: Packet,
     conn_id: Uuid,
+    messenger: Sender<MessengerOperations>,
     player_state: Sender<PlayerStateOperations>,
     block_state: Sender<BlockStateOperations>,
 ) {
+    //Add the connection as a subscriber. Unfortunately this happens every time we need to report
+    //state to them- in the future we should probably have an intermediary state like 'peer login'
+    //at which time we set them as a subscriber before entering this state
+
+    messenger
+        .send(MessengerOperations::Subscribe(SubscribeMessage { conn_id, local: false }))
+        .unwrap();
+
     //report current state to player (soon to be in it's own component for reuse)
     //the only state we keep right now is players
     player_state

--- a/src/keep_alive.rs
+++ b/src/keep_alive.rs
@@ -1,12 +1,12 @@
-use super::messenger::MessengerOperations;
-//use super::packet::{KeepAlive, Packet};
+use super::messenger::{MessengerOperations, BroadcastPacketMessage};
+use super::packet::{KeepAlive, Packet};
 use std::sync::mpsc::{Receiver, Sender};
 use std::thread::sleep;
 use std::time;
 use uuid::Uuid;
 
 const KEEP_ALIVE_PERIOD: u64 = 15;
-//const KEEP_ALIVE_VALUE: i64 = 16;
+const KEEP_ALIVE_VALUE: i64 = 16;
 
 pub enum KeepAliveOperations {
     New(NewKeepAliveConnectionMessage),
@@ -18,36 +18,18 @@ pub struct NewKeepAliveConnectionMessage {
 }
 
 pub fn start_keep_alive(
-    receiver: Receiver<KeepAliveOperations>,
-    _messenger: Sender<MessengerOperations>,
+    messenger: Sender<MessengerOperations>,
 ) {
-    let mut conn_ids: Vec<Uuid> = Vec::new();
-
     loop {
         sleep(time::Duration::from_secs(KEEP_ALIVE_PERIOD));
-
-        //after we wake up, add any new connections that were sent to us
-        while let Ok(msg) = receiver.try_recv() {
-            match msg {
-                KeepAliveOperations::New(msg) => {
-                    conn_ids.push(msg.conn_id);
-                }
-            }
-        }
-
-        //Turning this off for now- we don't need it for demo and it isn't properly implemented yet
-        //for peers
-        //
-        //send all the keep alives
-        //conn_ids.clone().into_iter().for_each(|conn_id| {
-        //send_packet!(
-        //messenger,
-        //conn_id,
-        //Packet::KeepAlive(KeepAlive {
-        //id: KEEP_ALIVE_VALUE
-        //})
-        //)
-        //.unwrap();
-        //})
+        broadcast_packet!(
+            messenger,
+            Packet::KeepAlive(KeepAlive {
+                id: KEEP_ALIVE_VALUE
+            }),
+            None,
+            false
+        )
+        .unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,13 +24,12 @@ use std::thread;
 
 fn main() {
     let (messenger_sender, messenger_receiver) = channel();
-    let (keep_alive_sender, keep_alive_receiver) = channel();
     let (inbound_packet_processor_sender, inbound_packet_processor_receiver) = channel();
     let (player_state_sender, player_state_receiver) = channel();
     let (block_state_sender, block_state_receiver) = channel();
     let (patchwork_state_sender, patchwork_state_receiver) = channel();
 
-    thread::spawn(move || start_messenger(messenger_receiver, keep_alive_sender));
+    thread::spawn(move || start_messenger(messenger_receiver));
 
     let messenger_clone = messenger_sender.clone();
     thread::spawn(move || start_player_state(player_state_receiver, messenger_clone));
@@ -49,7 +48,7 @@ fn main() {
     });
 
     let messenger_clone = messenger_sender.clone();
-    thread::spawn(move || start_keep_alive(keep_alive_receiver, messenger_clone));
+    thread::spawn(move || start_keep_alive(messenger_clone));
 
     let messenger_clone = messenger_sender.clone();
     let player_state_clone = player_state_sender.clone();

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -125,7 +125,7 @@ packet_boilerplate!(
         ]
     ),
     (
-        99,
+        _,
         EntityLookAndMove,
         0x29,
         [

--- a/src/packet_router.rs
+++ b/src/packet_router.rs
@@ -53,7 +53,7 @@ pub fn route_packet(
             TranslationUpdates::NoChange
         }
         Status::OutPeerSub => {
-            out_peer_sub_init::init_outgoing_peer_sub(packet, conn_id, player_state, block_state);
+            out_peer_sub_init::init_outgoing_peer_sub(packet, conn_id, messenger, player_state, block_state);
             TranslationUpdates::NoChange
         }
     }


### PR DESCRIPTION
Had to fix some entity id problems (we still had hardcoded 0 and uuids for entity ids sprinkled around the place)

had to introduce local broadcasting so that we don't send data about our peers to our peers (this is generally unwanted- and in the case where peers are mutually connected, causes an infinite loop)

otherwise this just builds on the previous few prs, getting the packet from the peer, translating it, then broadcasting it