### PR TITLE
cleanup messenger class, change subscriber types

### DIFF
--- a/src/initiation_protocols/login_init.rs
+++ b/src/initiation_protocols/login_init.rs
@@ -3,7 +3,7 @@ use super::game_state::block::BlockStateOperations;
 use super::game_state::patchwork::PatchworkStateOperations;
 use super::game_state::player;
 use super::game_state::player::{Angle, NewPlayerMessage, Player, PlayerStateOperations, Position};
-use super::messenger::{MessengerOperations, SendPacketMessage, SubscribeMessage};
+use super::messenger::{MessengerOperations, SendPacketMessage, SubscribeMessage, SubscriberType};
 use super::packet;
 use super::packet::Packet;
 use std::sync::mpsc::Sender;
@@ -79,7 +79,7 @@ fn confirm_login(
     messenger
         .send(MessengerOperations::Subscribe(SubscribeMessage {
             conn_id,
-            local: true,
+            typ: SubscriberType::All,
         }))
         .unwrap();
 

--- a/src/initiation_protocols/out_peer_sub_init.rs
+++ b/src/initiation_protocols/out_peer_sub_init.rs
@@ -4,7 +4,7 @@ use super::game_state::block;
 use super::game_state::block::BlockStateOperations;
 use super::game_state::player;
 use super::game_state::player::{NewPlayerMessage, Player, PlayerStateOperations, Position};
-use super::messenger::{MessengerOperations, SendPacketMessage, SubscribeMessage};
+use super::messenger::{MessengerOperations, SendPacketMessage, SubscribeMessage, SubscriberType};
 use super::packet::{EntityLookAndMove, Packet, PlayerInfo, SpawnPlayer};
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
@@ -24,7 +24,7 @@ pub fn init_outgoing_peer_sub(
     messenger
         .send(MessengerOperations::Subscribe(SubscribeMessage {
             conn_id,
-            local: false,
+            typ: SubscriberType::LocalOnly,
         }))
         .unwrap();
 


### PR DESCRIPTION
Mostly just clearing up confusion with the local, non-local subscriber thing. Now being more explicit with the enum All, LocalOnly to make it clear who's subscribing to what