### PR TITLE
Put translation data into packet macros

### DIFF
--- a/src/game_state/patchwork.rs
+++ b/src/game_state/patchwork.rs
@@ -10,6 +10,9 @@ use std::sync::mpsc::Sender;
 use std::thread;
 use uuid::Uuid;
 
+pub const ENTITY_ID_BLOCK_SIZE: i32 = 1000;
+pub const CHUNK_SIZE: i32 = 16;
+
 pub enum PatchworkStateOperations {
     New(NewMapMessage),
     Report,

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,8 +1,10 @@
 #![allow(unused_variables)]
 //Had to disable unused variables here since it wasn't working with packet::new
+use super::game_state::patchwork::{CHUNK_SIZE, ENTITY_ID_BLOCK_SIZE};
 use super::minecraft_protocol::{
     write_var_int, ChunkSection, MinecraftProtocolReader, MinecraftProtocolWriter,
 };
+use super::packet_processor::TranslationInfo;
 use std::io::{Cursor, Read, Write};
 
 // Format: (state (99 is outgoing), name, id, [ list of (field name, field type) ]
@@ -13,25 +15,25 @@ packet_boilerplate!(
         Handshake,
         0,
         [
-            (protocol_version, VarInt),
-            (server_address, String),
-            (server_port, UShort),
-            (next_state, VarInt)
+            (protocol_version, VarInt, Untranslated),
+            (server_address, String, Untranslated),
+            (server_port, UShort, Untranslated),
+            (next_state, VarInt, Untranslated)
         ]
     ),
     (1, StatusRequest, 0, []),
-    (1, Ping, 1, [(payload, Long)]),
-    (2, LoginStart, 0, [(username, String)]),
-    (3, KeepAlive, 0x21, [(id, Long)]),
+    (1, Ping, 1, [(payload, Long, Untranslated)]),
+    (2, LoginStart, 0, [(username, String, Untranslated)]),
+    (3, KeepAlive, 0x21, [(id, Long, Untranslated)]),
     (
         3,
         PlayerPosition,
         0x10,
         [
-            (x, Double),
-            (feet_y, Double),
-            (z, Double),
-            (on_ground, Boolean)
+            (x, Double, Untranslated),
+            (feet_y, Double, Untranslated),
+            (z, Double, Untranslated),
+            (on_ground, Boolean, Untranslated)
         ]
     ),
     (
@@ -39,12 +41,12 @@ packet_boilerplate!(
         PlayerPositionAndLook,
         0x11,
         [
-            (x, Double),
-            (feet_y, Double),
-            (z, Double),
-            (yaw, Float),
-            (pitch, Float),
-            (on_ground, Boolean)
+            (x, Double, Untranslated),
+            (feet_y, Double, Untranslated),
+            (z, Double, Untranslated),
+            (yaw, Float, Untranslated),
+            (pitch, Float, Untranslated),
+            (on_ground, Boolean, Untranslated)
         ]
     ),
     (
@@ -52,27 +54,27 @@ packet_boilerplate!(
         PlayerLook,
         0x12,
         [
-            (yaw, Float),
-            (pitch, Float),
-            (on_ground, Boolean)
+            (yaw, Float, Untranslated),
+            (pitch, Float, Untranslated),
+            (on_ground, Boolean, Untranslated)
         ]
     ),
     (6, ReportState, 0x1, []),
-    (99, Pong, 1, [(payload, Long)]),
-    (99, StatusResponse, 0, [(json_response, String)]),
-    (99, LoginSuccess, 2, [(uuid, String), (username, String)]),
+    (99, Pong, 1, [(payload, Long, Untranslated)]),
+    (99, StatusResponse, 0, [(json_response, String, Untranslated)]),
+    (99, LoginSuccess, 2, [(uuid, String, Untranslated), (username, String, Untranslated)]),
     (
         99,
         JoinGame,
         0x25,
         [
-            (entity_id, Int),
-            (gamemode, UByte),
-            (dimension, Int),
-            (difficulty, UByte),
-            (max_players, UByte),
-            (level_type, String),
-            (reduced_debug_info, Boolean)
+            (entity_id, Int, EntityId),
+            (gamemode, UByte, Untranslated),
+            (dimension, Int, Untranslated),
+            (difficulty, UByte, Untranslated),
+            (max_players, UByte, Untranslated),
+            (level_type, String, Untranslated),
+            (reduced_debug_info, Boolean, Untranslated)
         ]
     ),
     (
@@ -80,13 +82,13 @@ packet_boilerplate!(
         ClientboundPlayerPositionAndLook,
         0x32,
         [
-            (x, Double),
-            (y, Double),
-            (z, Double),
-            (yaw, Float),
-            (pitch, Float),
-            (flags, Byte),
-            (teleport_id, VarInt)
+            (x, Double, Untranslated),
+            (y, Double, Untranslated),
+            (z, Double, Untranslated),
+            (yaw, Float, Untranslated),
+            (pitch, Float, Untranslated),
+            (flags, Byte, Untranslated),
+            (teleport_id, VarInt, Untranslated)
         ]
     ),
     (
@@ -94,14 +96,14 @@ packet_boilerplate!(
         ChunkData,
         0x22,
         [
-            (chunk_x, Int),
-            (chunk_z, Int),
-            (full_chunk, Boolean), //always true
-            (primary_bit_mask, VarInt),
-            (size, VarInt),
-            (data, ChunkSection), //actually a chunk array, but can pretend its 1 for now
-            (biomes, IntArray),
-            (number_of_block_entities, VarInt)
+            (chunk_x, Int, XChunk),
+            (chunk_z, Int, Untranslated),
+            (full_chunk, Boolean, Untranslated), //always true
+            (primary_bit_mask, VarInt, Untranslated),
+            (size, VarInt, Untranslated),
+            (data, ChunkSection, Untranslated), //actually a chunk array, but can pretend its 1 for now
+            (biomes, IntArray, Untranslated),
+            (number_of_block_entities, VarInt, Untranslated)
         ]
     ),
     (
@@ -109,14 +111,14 @@ packet_boilerplate!(
         PlayerInfo,
         0x30,
         [
-            (action, VarInt),
-            (number_of_players, VarInt),
-            (uuid, u128),
-            (name, String),
-            (number_of_properties, VarInt),
-            (gamemode, VarInt),
-            (ping, VarInt),
-            (has_display_name, Boolean)
+            (action, VarInt, Untranslated),
+            (number_of_players, VarInt, Untranslated),
+            (uuid, u128, Untranslated),
+            (name, String, Untranslated),
+            (number_of_properties, VarInt, Untranslated),
+            (gamemode, VarInt, Untranslated),
+            (ping, VarInt, Untranslated),
+            (has_display_name, Boolean, Untranslated)
         ]
     ),
     (
@@ -124,14 +126,14 @@ packet_boilerplate!(
         SpawnPlayer,
         0x05,
         [
-            (entity_id, VarInt),
-            (uuid, u128),
-            (x, Double),
-            (y, Double),
-            (z, Double),
-            (yaw, UByte), // represents angle * (360/256). Might want to eventually make this its own type
-            (pitch, UByte), // for now lets just set it to 0
-            (entity_metadata_terminator, UByte)  // always 0xff until we implement entity metadata
+            (entity_id, VarInt, EntityId),
+            (uuid, u128, Untranslated),
+            (x, Double, XEntity),
+            (y, Double, Untranslated),
+            (z, Double, Untranslated),
+            (yaw, UByte, Untranslated), // represents angle * (360/256). Might want to eventually make this its own type
+            (pitch, UByte, Untranslated), // for now lets just set it to 0
+            (entity_metadata_terminator, UByte, Untranslated)  // always 0xff until we implement entity metadata
         ]
     ),
     (
@@ -139,13 +141,13 @@ packet_boilerplate!(
         EntityLookAndMove,
         0x29,
         [
-            (entity_id, VarInt),
-            (delta_x, Short),
-            (delta_y, Short),
-            (delta_z, Short),
-            (yaw, UByte),
-            (pitch, UByte),
-            (on_ground, Boolean)
+            (entity_id, VarInt, EntityId),
+            (delta_x, Short, Untranslated),
+            (delta_y, Short, Untranslated),
+            (delta_z, Short, Untranslated),
+            (yaw, UByte, Untranslated),
+            (pitch, UByte, Untranslated),
+            (on_ground, Boolean, Untranslated)
         ]
     )
 );

--- a/src/packet_router.rs
+++ b/src/packet_router.rs
@@ -3,8 +3,7 @@ use super::game_state::patchwork::PatchworkStateOperations;
 use super::game_state::player::PlayerStateOperations;
 use super::gameplay_router;
 use super::initiation_protocols::{
-    border_cross_login, client_ping, handshake, in_peer_sub, login,
-    out_peer_sub,
+    border_cross_login, client_ping, handshake, in_peer_sub, login, out_peer_sub,
 };
 use super::messenger::MessengerOperations;
 use super::packet::Packet;


### PR DESCRIPTION
Added it as a secondary type of every field. Now at least we don't need to do anything per packet class- we'll see if this is still sufficient going forward