### PR TITLE
Added type arguments, gave intarray a type argument of length

### DIFF
--- a/src/minecraft_protocol.rs
+++ b/src/minecraft_protocol.rs
@@ -13,7 +13,7 @@ pub trait MinecraftProtocolReader {
     fn read_string(&mut self) -> String;
     fn read_u_128(&mut self) -> u128;
     fn read_int(&mut self) -> i32;
-    fn read_int_array(&mut self) -> Vec<i32>;
+    fn read_int_array(&mut self, length: u32) -> Vec<i32>;
     fn read_chunk_section(&mut self) -> ChunkSection;
     fn read_float(&mut self) -> f32;
     fn read_double(&mut self) -> f64;
@@ -167,10 +167,9 @@ impl<T: Read> MinecraftProtocolReader for T {
         self.read_i32::<BigEndian>().unwrap()
     }
 
-    fn read_int_array(&mut self) -> Vec<i32> {
-        // only supports arrays with 256 entires (to support biome array)
+    fn read_int_array(&mut self, length: u32) -> Vec<i32> {
         let mut v = Vec::<i32>::new();
-        for _ in 0..256 {
+        for _ in 0..length {
             v.push(self.read_i32::<BigEndian>().unwrap());
         }
         v

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -102,7 +102,7 @@ packet_boilerplate!(
             (primary_bit_mask, VarInt),
             (size, VarInt),
             (data, ChunkSection), //actually a chunk array, but can pretend its 1 for now
-            (biomes, IntArray),
+            (biomes, IntArray(256)),
             (number_of_block_entities, VarInt)
         ]
     ),


### PR DESCRIPTION
Had to undo some syntax sugar from the last PR to make this work. Now you can append a type argument after the type which can be used to inform the reading and writing process. Here I'm using it to specify the length of an array type.