### PR TITLE
Add block id reading to minecraft protocol

### DIFF
--- a/src/game_state/block.rs
+++ b/src/game_state/block.rs
@@ -21,12 +21,24 @@ pub struct ReportMessage {
 fn fill_dummy_block_ids(ids: &mut Vec<i32>) {
     //just some random pattern
     while ids.len() < 4096 {
-        match ids.len() % 2 {
+        match ids.len() % 6 {
             0 => {
                 ids.push(5);
             }
             1 => {
                 ids.push(3);
+            }
+            2 => {
+                ids.push(1);
+            }
+            3 => {
+                ids.push(1);
+            }
+            4 => {
+                ids.push(1);
+            }
+            5 => {
+                ids.push(1);
             }
             _ => {
                 panic!("if this happens, all hope is lost");


### PR DESCRIPTION
This fixes https://github.com/DuncanUszkay1/Patchwork/issues/63

Here's what went wrong:
- I changed the block data packet writing procedure to actually use the block ids provided instead of a hardcoded block ids
- Our packet reading procedure was returning empty vectors for blocks/light values/etc
- Since we always read packets from peers before sending them to clients, we would read the block packet, then try to write a block packet with an empty block id array which would cause the client to crash
- To fix this, I implemented a read procedure for block ids

I also changed the block pattern to be a little more dynamic