### PR TITLE
Implement entity head look for players

### DIFF
--- a/src/game_state/player.rs
+++ b/src/game_state/player.rs
@@ -1,7 +1,8 @@
 use super::super::minecraft_protocol::float_to_angle;
 use super::messenger::{BroadcastPacketMessage, MessengerOperations, SendPacketMessage};
 use super::packet::{
-    ClientboundPlayerPositionAndLook, EntityLookAndMove, JoinGame, Packet, PlayerInfo, SpawnPlayer,
+    ClientboundPlayerPositionAndLook, EntityHeadLook, EntityLookAndMove, JoinGame, Packet,
+    PlayerInfo, SpawnPlayer,
 };
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -97,6 +98,13 @@ fn handle_message(
                     Some(player.conn_id),
                     true
                 )
+                .unwrap();
+                broadcast_packet!(
+                    messenger,
+                    Packet::EntityHeadLook(player.entity_head_look()),
+                    Some(player.conn_id),
+                    true
+                )
                 .unwrap()
             });
         }
@@ -156,6 +164,13 @@ impl Player {
             pitch: 0.0,
             flags: 0,
             teleport_id: 0,
+        }
+    }
+
+    fn entity_head_look(&self) -> EntityHeadLook {
+        EntityHeadLook {
+            entity_id: self.entity_id,
+            angle: float_to_angle(self.angle.yaw),
         }
     }
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -138,6 +138,15 @@ packet_boilerplate!(
     ),
     (
         _,
+        EntityHeadLook,
+        0x39,
+        [
+            (entity_id, VarInt, EntityId),
+            (angle, UByte)
+        ]
+    ),
+    (
+        _,
         EntityLookAndMove,
         0x29,
         [


### PR DESCRIPTION
<!---The purpose of this template is to make our PRs more consistent and have them break shit less often-->
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/66

### Why
Players heads would only face one direction on the XZ axis before, this fixes that

### What
Add the entity head packet, send it whenever the players look updates

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
