### PR TITLE
Refactor patchwork to keep track of remote and peer maps

### DIFF
--- a/src/game_state/patchwork.rs
+++ b/src/game_state/patchwork.rs
@@ -34,22 +34,56 @@ pub struct Peer {
     pub address: String,
 }
 
-impl Patchwork {
-    pub fn new() -> Patchwork {
-        Patchwork {
-            maps: Vec::<Map>::new(),
+pub fn start(
+    receiver: Receiver<PatchworkStateOperations>,
+    messenger: Sender<MessengerOperations>,
+    inbound_packet_processor: Sender<PacketProcessorOperations>,
+) {
+    let mut patchwork = Patchwork::new();
+
+    while let Ok(msg) = receiver.recv() {
+        match msg {
+            PatchworkStateOperations::New(msg) => patchwork.add_peer_map(
+                msg.peer,
+                messenger.clone(),
+                inbound_packet_processor.clone(),
+            ),
+            PatchworkStateOperations::Report => {
+                patchwork.clone().report(messenger.clone());
+            }
         }
     }
+}
 
-    pub fn add_map(&mut self, peer: Peer) -> Map {
-        let map = Map {
+impl Patchwork {
+    pub fn new() -> Patchwork {
+        let mut patchwork = Patchwork { maps: Vec::new() };
+        patchwork.create_local_map();
+        patchwork
+    }
+
+    pub fn create_local_map(&mut self) {
+        self.maps.push(Map::Local(LocalMap {
             position: self.next_position(),
-            peer,
             entity_id_block: self.next_entity_id_block(),
-            conn_id: Uuid::new_v4(),
-        };
-        self.maps.push(map.clone());
-        map
+        }));
+    }
+
+    pub fn add_peer_map(
+        &mut self,
+        peer: Peer,
+        messenger: Sender<MessengerOperations>,
+        inbound_packet_processor: Sender<PacketProcessorOperations>,
+    ) {
+        if let Ok(map) = RemoteMap::try_new(
+            messenger,
+            inbound_packet_processor,
+            peer,
+            self.next_position(),
+            self.next_entity_id_block(),
+        ) {
+            self.maps.push(Map::Remote(map));
+        }
     }
 
     pub fn report(self, messenger: Sender<MessengerOperations>) {
@@ -66,16 +100,32 @@ impl Patchwork {
     // For now, just line up all the maps in a row
     fn next_position(&self) -> Position {
         let len = self.maps.len() as i32;
-        Position { x: len + 1, z: 0 }
+        Position { x: len, z: 0 }
     }
 }
 
+trait Reportable {
+    fn report(&self, messenger: Sender<MessengerOperations>);
+}
+
 #[derive(Debug, Clone)]
-struct Map {
+enum Map {
+    Local(LocalMap),
+    Remote(RemoteMap),
+}
+
+#[derive(Debug, Clone)]
+struct RemoteMap {
     pub position: Position,
     pub entity_id_block: i32,
-    pub peer: Peer,
     pub conn_id: Uuid,
+}
+
+#[derive(Debug, Clone)]
+struct LocalMap {
+    pub position: Position,
+    pub entity_id_block: i32,
+    // pub block_state_sender
 }
 
 #[derive(Debug, Clone)]
@@ -84,89 +134,28 @@ pub struct Position {
     pub z: i32,
 }
 
-impl Map {
-    fn connect(
-        &self,
-        messenger: Sender<MessengerOperations>,
-        inbound_packet_processor: Sender<PacketProcessorOperations>,
-    ) -> Result<(), io::Error> {
-        let stream = server::new_connection(self.peer.address.clone(), self.peer.port)?;
-        messenger
-            .send(MessengerOperations::New(NewConnectionMessage {
-                conn_id: self.conn_id,
-                socket: stream.try_clone().unwrap(),
-            }))
-            .unwrap();
-        inbound_packet_processor
-            .send(PacketProcessorOperations::SetTranslationData(
-                TranslationDataMessage {
-                    conn_id: self.conn_id,
-                    updates: vec![
-                        TranslationUpdates::State(5),
-                        TranslationUpdates::EntityIdBlock(self.entity_id_block),
-                        TranslationUpdates::XOrigin(self.position.x),
-                    ],
-                },
-            ))
-            .unwrap();
-        let messenger_clone = messenger.clone();
-        let inbound_packet_processor_clone = inbound_packet_processor.clone();
-        let conn_id_clone = self.conn_id;
-        thread::spawn(move || {
-            server::handle_connection(
-                stream.try_clone().unwrap(),
-                inbound_packet_processor_clone,
-                messenger_clone,
-                conn_id_clone,
-            );
-        });
-        Ok(())
+impl Reportable for Map {
+    fn report(&self, messenger: Sender<MessengerOperations>) {
+        match self {
+            Map::Remote(map) => {
+                map.report(messenger);
+            }
+            Map::Local(map) => {
+                map.report(messenger);
+            }
+        }
     }
+}
 
-    fn create_event_listener(
-        self,
-        messenger: Sender<MessengerOperations>,
-        inbound_packet_processor: Sender<PacketProcessorOperations>,
-    ) {
-        if let Ok(()) = self.connect(messenger.clone(), inbound_packet_processor) {
-            send_packet!(
-                messenger,
-                self.conn_id,
-                Packet::Handshake(Handshake {
-                    protocol_version: 404,
-                    server_address: self.peer.address.clone(),
-                    server_port: self.peer.port,
-                    next_state: 6,
-                })
-            )
-            .unwrap();
-
-            //we send two packets because our protocol requires at least two packets to be sent
-            //before it can do anything- the first is a handshake, then the second one it can
-            //actually response to (it ignores the type of packet, so we just send it random data)
-            //to be changed later with a real request packet
-            send_packet!(
-                messenger,
-                self.conn_id,
-                Packet::Handshake(Handshake {
-                    protocol_version: 404,
-                    server_address: self.peer.address.clone(),
-                    server_port: self.peer.port,
-                    next_state: 6,
-                })
-            )
-            .unwrap();
-        };
-    }
-
-    fn report(self, messenger: Sender<MessengerOperations>) {
+impl Reportable for RemoteMap {
+    fn report(&self, messenger: Sender<MessengerOperations>) {
         send_packet!(
             messenger,
             self.conn_id,
             Packet::Handshake(Handshake {
                 protocol_version: 404,
-                server_address: self.peer.address.clone(),
-                server_port: self.peer.port,
+                server_address: String::from(""), //Neither of these fields are actually used
+                server_port: 0,
                 next_state: 5,
             })
         )
@@ -174,23 +163,84 @@ impl Map {
     }
 }
 
-pub fn start(
-    receiver: Receiver<PatchworkStateOperations>,
-    messenger: Sender<MessengerOperations>,
-    inbound_packet_processor: Sender<PacketProcessorOperations>,
-) {
-    let mut patchwork = Patchwork::new();
+impl Reportable for LocalMap {
+    fn report(&self, _messenger: Sender<MessengerOperations>) {
+        // Eventaully this method will call the block state reporter, which will belong to the
+        // local map. For now this does nothing
+    }
+}
 
-    while let Ok(msg) = receiver.recv() {
-        match msg {
-            PatchworkStateOperations::New(msg) => {
-                patchwork
-                    .add_map(msg.peer)
-                    .create_event_listener(messenger.clone(), inbound_packet_processor.clone());
-            }
-            PatchworkStateOperations::Report => {
-                patchwork.clone().report(messenger.clone());
-            }
-        }
+impl RemoteMap {
+    pub fn try_new(
+        messenger: Sender<MessengerOperations>,
+        inbound_packet_processor: Sender<PacketProcessorOperations>,
+        peer: Peer,
+        position: Position,
+        entity_id_block: i32,
+    ) -> Result<RemoteMap, io::Error> {
+        let conn_id = Uuid::new_v4();
+        let stream = server::new_connection(peer.address.clone(), peer.port)?;
+        messenger
+            .send(MessengerOperations::New(NewConnectionMessage {
+                conn_id,
+                socket: stream.try_clone().unwrap(),
+            }))
+            .unwrap();
+        inbound_packet_processor
+            .send(PacketProcessorOperations::SetTranslationData(
+                TranslationDataMessage {
+                    conn_id,
+                    updates: vec![
+                        TranslationUpdates::State(5),
+                        TranslationUpdates::EntityIdBlock(entity_id_block),
+                        TranslationUpdates::XOrigin(position.x),
+                    ],
+                },
+            ))
+            .unwrap();
+
+        let messenger_clone = messenger.clone();
+        let inbound_packet_processor_clone = inbound_packet_processor.clone();
+        thread::spawn(move || {
+            server::handle_connection(
+                stream.try_clone().unwrap(),
+                inbound_packet_processor_clone,
+                messenger_clone,
+                conn_id,
+            );
+        });
+        let map = RemoteMap {
+            position,
+            entity_id_block,
+            conn_id,
+        };
+        send_packet!(
+            messenger,
+            conn_id,
+            Packet::Handshake(Handshake {
+                protocol_version: 404,
+                server_address: peer.address.clone(),
+                server_port: peer.port,
+                next_state: 6,
+            })
+        )
+        .unwrap();
+
+        //we send two packets because our protocol requires at least two packets to be sent
+        //before it can do anything- the first is a handshake, then the second one it can
+        //actually response to (it ignores the type of packet, so we just send it random data)
+        //to be changed later with a real request packet
+        send_packet!(
+            messenger,
+            conn_id,
+            Packet::Handshake(Handshake {
+                protocol_version: 404,
+                server_address: peer.address.clone(),
+                server_port: peer.port,
+                next_state: 6,
+            })
+        )
+        .unwrap();
+        Ok(map)
     }
 }

--- a/src/packet_router.rs
+++ b/src/packet_router.rs
@@ -40,6 +40,7 @@ pub fn route_packet(
             TranslationUpdates::NoChange
         }
         Status::Play => {
+            //patchwork_state.send(PatchworkStateOperations::RoutePlayerPacket(RouteMessage { packet: packet.clone(), conn_id })).unwrap();
             gameplay_router::route_packet(packet, conn_id, player_state);
             TranslationUpdates::NoChange
         }


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/73

### Why 
Local maps were being ignored by the patchwork object. This doesn't really make sense, and forces a bunch of special case logic down the road with player anchors.

### What
Change map to an enum with two different types, a local and remote map. 
I also reordered the code in this file since it's getting jumbled. Definitely needs to be split into a few files, I'll do that next

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
