### PR TITLE
Refactor for patchwork file, split into two

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -2,7 +2,7 @@ pub mod block;
 pub mod patchwork;
 pub mod player;
 
+use super::map;
 use super::messenger;
 use super::packet;
 use super::packet_processor;
-use super::server;

--- a/src/game_state/patchwork.rs
+++ b/src/game_state/patchwork.rs
@@ -1,14 +1,8 @@
-use super::messenger::{MessengerOperations, NewConnectionMessage, SendPacketMessage};
-use super::packet::{Handshake, Packet};
-use super::packet_processor::{
-    PacketProcessorOperations, TranslationDataMessage, TranslationUpdates,
-};
-use super::server;
-use std::io;
+use super::map::{LocalMap, Map, Peer, Position, RemoteMap};
+use super::messenger::MessengerOperations;
+use super::packet_processor::PacketProcessorOperations;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
-use std::thread;
-use uuid::Uuid;
 
 pub const ENTITY_ID_BLOCK_SIZE: i32 = 1000;
 pub const CHUNK_SIZE: i32 = 16;
@@ -26,12 +20,6 @@ pub struct NewMapMessage {
 #[derive(Debug, Clone)]
 struct Patchwork {
     pub maps: Vec<Map>,
-}
-
-#[derive(Debug, Clone)]
-pub struct Peer {
-    pub port: u16,
-    pub address: String,
 }
 
 pub fn start(
@@ -94,153 +82,12 @@ impl Patchwork {
 
     // get the next block of size 1000 entity ids assigned to this map
     fn next_entity_id_block(&self) -> i32 {
-        (self.maps.len() + 1) as i32
+        self.maps.len() as i32
     }
 
     // For now, just line up all the maps in a row
     fn next_position(&self) -> Position {
         let len = self.maps.len() as i32;
         Position { x: len, z: 0 }
-    }
-}
-
-trait Reportable {
-    fn report(&self, messenger: Sender<MessengerOperations>);
-}
-
-#[derive(Debug, Clone)]
-enum Map {
-    Local(LocalMap),
-    Remote(RemoteMap),
-}
-
-#[derive(Debug, Clone)]
-struct RemoteMap {
-    pub position: Position,
-    pub entity_id_block: i32,
-    pub conn_id: Uuid,
-}
-
-#[derive(Debug, Clone)]
-struct LocalMap {
-    pub position: Position,
-    pub entity_id_block: i32,
-    // pub block_state_sender
-}
-
-#[derive(Debug, Clone)]
-pub struct Position {
-    pub x: i32,
-    pub z: i32,
-}
-
-impl Reportable for Map {
-    fn report(&self, messenger: Sender<MessengerOperations>) {
-        match self {
-            Map::Remote(map) => {
-                map.report(messenger);
-            }
-            Map::Local(map) => {
-                map.report(messenger);
-            }
-        }
-    }
-}
-
-impl Reportable for RemoteMap {
-    fn report(&self, messenger: Sender<MessengerOperations>) {
-        send_packet!(
-            messenger,
-            self.conn_id,
-            Packet::Handshake(Handshake {
-                protocol_version: 404,
-                server_address: String::from(""), //Neither of these fields are actually used
-                server_port: 0,
-                next_state: 5,
-            })
-        )
-        .unwrap();
-    }
-}
-
-impl Reportable for LocalMap {
-    fn report(&self, _messenger: Sender<MessengerOperations>) {
-        // Eventaully this method will call the block state reporter, which will belong to the
-        // local map. For now this does nothing
-    }
-}
-
-impl RemoteMap {
-    pub fn try_new(
-        messenger: Sender<MessengerOperations>,
-        inbound_packet_processor: Sender<PacketProcessorOperations>,
-        peer: Peer,
-        position: Position,
-        entity_id_block: i32,
-    ) -> Result<RemoteMap, io::Error> {
-        let conn_id = Uuid::new_v4();
-        let stream = server::new_connection(peer.address.clone(), peer.port)?;
-        messenger
-            .send(MessengerOperations::New(NewConnectionMessage {
-                conn_id,
-                socket: stream.try_clone().unwrap(),
-            }))
-            .unwrap();
-        inbound_packet_processor
-            .send(PacketProcessorOperations::SetTranslationData(
-                TranslationDataMessage {
-                    conn_id,
-                    updates: vec![
-                        TranslationUpdates::State(5),
-                        TranslationUpdates::EntityIdBlock(entity_id_block),
-                        TranslationUpdates::XOrigin(position.x),
-                    ],
-                },
-            ))
-            .unwrap();
-
-        let messenger_clone = messenger.clone();
-        let inbound_packet_processor_clone = inbound_packet_processor.clone();
-        thread::spawn(move || {
-            server::handle_connection(
-                stream.try_clone().unwrap(),
-                inbound_packet_processor_clone,
-                messenger_clone,
-                conn_id,
-            );
-        });
-        let map = RemoteMap {
-            position,
-            entity_id_block,
-            conn_id,
-        };
-        send_packet!(
-            messenger,
-            conn_id,
-            Packet::Handshake(Handshake {
-                protocol_version: 404,
-                server_address: peer.address.clone(),
-                server_port: peer.port,
-                next_state: 6,
-            })
-        )
-        .unwrap();
-
-        //we send two packets because our protocol requires at least two packets to be sent
-        //before it can do anything- the first is a handshake, then the second one it can
-        //actually response to (it ignores the type of packet, so we just send it random data)
-        //to be changed later with a real request packet
-        send_packet!(
-            messenger,
-            conn_id,
-            Packet::Handshake(Handshake {
-                protocol_version: 404,
-                server_address: peer.address.clone(),
-                server_port: peer.port,
-                next_state: 6,
-            })
-        )
-        .unwrap();
-        Ok(map)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,13 +8,15 @@ mod game_state;
 mod gameplay_router;
 mod initiation_protocols;
 mod keep_alive;
+mod map;
 mod minecraft_protocol;
 mod packet;
 mod packet_processor;
 mod packet_router;
 mod server;
 
-use game_state::patchwork::{NewMapMessage, PatchworkStateOperations, Peer};
+use game_state::patchwork::{NewMapMessage, PatchworkStateOperations};
+use map::Peer;
 use service::ServiceInstance;
 
 use std::env;

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,0 +1,138 @@
+use super::messenger::{MessengerOperations, NewConnectionMessage, SendPacketMessage};
+use super::packet::{Handshake, Packet};
+use super::packet_processor::{
+    PacketProcessorOperations, TranslationDataMessage, TranslationUpdates,
+};
+use super::server;
+use std::io;
+use std::sync::mpsc::Sender;
+use std::thread;
+use uuid::Uuid;
+
+#[derive(Debug, Clone)]
+pub enum Map {
+    Local(LocalMap),
+    Remote(RemoteMap),
+}
+
+#[derive(Debug, Clone)]
+pub struct Peer {
+    pub port: u16,
+    pub address: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RemoteMap {
+    pub position: Position,
+    pub entity_id_block: i32,
+    pub conn_id: Uuid,
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalMap {
+    pub position: Position,
+    pub entity_id_block: i32,
+    // pub block_state_sender
+}
+
+#[derive(Debug, Clone)]
+pub struct Position {
+    pub x: i32,
+    pub z: i32,
+}
+
+impl Map {
+    pub fn report(&self, messenger: Sender<MessengerOperations>) {
+        match self {
+            Map::Remote(map) => {
+                send_packet!(
+                    messenger,
+                    map.conn_id,
+                    Packet::Handshake(Handshake {
+                        protocol_version: 404,
+                        server_address: String::from(""), //Neither of these fields are actually used
+                        server_port: 0,
+                        next_state: 5,
+                    })
+                )
+                .unwrap();
+            }
+            Map::Local(_map) => {}
+        }
+    }
+}
+
+impl RemoteMap {
+    pub fn try_new(
+        messenger: Sender<MessengerOperations>,
+        inbound_packet_processor: Sender<PacketProcessorOperations>,
+        peer: Peer,
+        position: Position,
+        entity_id_block: i32,
+    ) -> Result<RemoteMap, io::Error> {
+        let conn_id = Uuid::new_v4();
+        let stream = server::new_connection(peer.address.clone(), peer.port)?;
+        messenger
+            .send(MessengerOperations::New(NewConnectionMessage {
+                conn_id,
+                socket: stream.try_clone().unwrap(),
+            }))
+            .unwrap();
+        inbound_packet_processor
+            .send(PacketProcessorOperations::SetTranslationData(
+                TranslationDataMessage {
+                    conn_id,
+                    updates: vec![
+                        TranslationUpdates::State(5),
+                        TranslationUpdates::EntityIdBlock(entity_id_block),
+                        TranslationUpdates::XOrigin(position.x),
+                    ],
+                },
+            ))
+            .unwrap();
+
+        let messenger_clone = messenger.clone();
+        let inbound_packet_processor_clone = inbound_packet_processor.clone();
+        thread::spawn(move || {
+            server::handle_connection(
+                stream.try_clone().unwrap(),
+                inbound_packet_processor_clone,
+                messenger_clone,
+                conn_id,
+            );
+        });
+        let map = RemoteMap {
+            position,
+            entity_id_block,
+            conn_id,
+        };
+        send_packet!(
+            messenger,
+            conn_id,
+            Packet::Handshake(Handshake {
+                protocol_version: 404,
+                server_address: peer.address.clone(),
+                server_port: peer.port,
+                next_state: 6,
+            })
+        )
+        .unwrap();
+
+        //we send two packets because our protocol requires at least two packets to be sent
+        //before it can do anything- the first is a handshake, then the second one it can
+        //actually response to (it ignores the type of packet, so we just send it random data)
+        //to be changed later with a real request packet
+        send_packet!(
+            messenger,
+            conn_id,
+            Packet::Handshake(Handshake {
+                protocol_version: 404,
+                server_address: peer.address.clone(),
+                server_port: peer.port,
+                next_state: 6,
+            })
+        )
+        .unwrap();
+        Ok(map)
+    }
+}


### PR DESCRIPTION
### Why 
File was getting too big. 

### What 
Split out some of the map stuff into its own file. Far from perfect but better than before

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
