### PR TITLE
Detect Map Index of player

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -35,7 +35,7 @@ pub struct LocalMap {
     // pub block_state_sender
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Position {
     pub x: i32,
     pub z: i32,
@@ -58,6 +58,13 @@ impl Map {
                 .unwrap();
             }
             Map::Local(_map) => {}
+        }
+    }
+
+    pub fn position(self) -> Position {
+        match self {
+            Map::Remote(map) => map.position,
+            Map::Local(map) => map.position,
         }
     }
 }

--- a/src/packet_router.rs
+++ b/src/packet_router.rs
@@ -1,5 +1,5 @@
 use super::game_state::block::BlockStateOperations;
-use super::game_state::patchwork::PatchworkStateOperations;
+use super::game_state::patchwork::{PatchworkStateOperations, RouteMessage};
 use super::game_state::player::PlayerStateOperations;
 use super::gameplay_router;
 use super::initiation_protocols::{
@@ -40,7 +40,12 @@ pub fn route_packet(
             TranslationUpdates::NoChange
         }
         Status::Play => {
-            //patchwork_state.send(PatchworkStateOperations::RoutePlayerPacket(RouteMessage { packet: packet.clone(), conn_id })).unwrap();
+            patchwork_state
+                .send(PatchworkStateOperations::RoutePlayerPacket(RouteMessage {
+                    packet: packet.clone(),
+                    conn_id,
+                }))
+                .unwrap();
             gameplay_router::route_packet(packet, conn_id, player_state);
             TranslationUpdates::NoChange
         }


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/70

### Why
For player anchors to work, we need to know what map the player is on at all times.

### What
Patchwork now receives a copy of all packets and inspects them to determine the index of the player

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
