### PR TITLE
Divert packets through patchwork state before going to gameplay router

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -2,6 +2,7 @@ pub mod block;
 pub mod patchwork;
 pub mod player;
 
+use super::gameplay_router;
 use super::map;
 use super::messenger;
 use super::packet;

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn main() {
         (
             module: game_state::patchwork::start,
             name: patchwork_state,
-            dependencies: [messenger, inbound_packet_processor]
+            dependencies: [messenger, inbound_packet_processor, player_state]
         ),
         (
             module: messenger::start,

--- a/src/packet_router.rs
+++ b/src/packet_router.rs
@@ -1,7 +1,6 @@
 use super::game_state::block::BlockStateOperations;
 use super::game_state::patchwork::{PatchworkStateOperations, RouteMessage};
 use super::game_state::player::PlayerStateOperations;
-use super::gameplay_router;
 use super::initiation_protocols::{
     border_cross_login, client_ping, handshake, in_peer_sub, login, out_peer_sub,
 };
@@ -46,7 +45,6 @@ pub fn route_packet(
                     conn_id,
                 }))
                 .unwrap();
-            gameplay_router::route_packet(packet, conn_id, player_state);
             TranslationUpdates::NoChange
         }
         Status::BorderCrossLogin => {


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/70

### Why
At the packet router stage, we don't actually know where the packet should go since it's dependent on state (the position of the player). So it needs to route through the game state, in this case the patchwork state, to determine what to do with the packet

### What
Packets now go through the patchwork state before arriving at the gameplay router

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
