### PR TITLE
Spawn player on border crossing

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -7,3 +7,4 @@ use super::map;
 use super::messenger;
 use super::packet;
 use super::packet_processor;
+use super::server;

--- a/src/game_state/patchwork.rs
+++ b/src/game_state/patchwork.rs
@@ -1,12 +1,15 @@
 use super::gameplay_router;
 use super::map::{LocalMap, Map, Peer, Position, RemoteMap};
-use super::messenger::MessengerOperations;
+use super::messenger::{MessengerOperations, NewConnectionMessage, SendPacketMessage};
+use super::packet;
 use super::packet::Packet;
 use super::packet_processor::PacketProcessorOperations;
 use super::player::PlayerStateOperations;
+use super::server;
+use std::collections::HashMap;
+use std::io;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
-use std::collections::HashMap;
 use uuid::Uuid;
 
 pub const ENTITY_ID_BLOCK_SIZE: i32 = 1000;
@@ -46,16 +49,49 @@ pub fn start(
             ),
             PatchworkStateOperations::RoutePlayerPacket(msg) => {
                 let patchwork_clone = patchwork.clone();
-                let map_index = patchwork.player_map_indexes.entry(msg.conn_id);
+                let anchor = patchwork
+                    .player_anchors
+                    .entry(msg.conn_id)
+                    .or_insert(Anchor {
+                        map_index: 0,
+                        conn_id: None,
+                    });
                 if let Some(position) = extract_map_position(msg.clone().packet) {
                     let new_map_index = patchwork_clone.position_map_index(position);
-                    let map_index = map_index.or_insert(new_map_index);
-                    if new_map_index != *map_index {
-                        println!("border crossing! from {:?} to {:?}", new_map_index, map_index);
-                        *map_index = new_map_index;
+                    if new_map_index != anchor.map_index {
+                        println!(
+                            "border crossing! from {:?} to {:?}",
+                            new_map_index, anchor.map_index
+                        );
+                        *anchor = match &patchwork.maps[new_map_index] {
+                            Map::Remote(map) => {
+                                Anchor::connect(map.peer.clone(), new_map_index, messenger.clone())
+                                    .unwrap()
+                            }
+                            Map::Local(map) => Anchor {
+                                conn_id: None,
+                                map_index: new_map_index,
+                            },
+                        }
                     }
                 }
-                gameplay_router::route_packet(msg.packet, msg.conn_id, player_state.clone());
+                match &patchwork.maps[anchor.map_index] {
+                    Map::Local(_) => {
+                        println!("handling locally");
+                        gameplay_router::route_packet(
+                            msg.packet,
+                            msg.conn_id,
+                            player_state.clone(),
+                        );
+                    }
+                    Map::Remote(_) => match msg.packet {
+                        Packet::Unknown => {}
+                        _ => {
+                            println!("forwarding");
+                            send_packet!(messenger, anchor.conn_id.unwrap(), msg.packet).unwrap();
+                        }
+                    },
+                }
             }
             PatchworkStateOperations::Report => {
                 patchwork.clone().report(messenger.clone());
@@ -79,15 +115,67 @@ fn extract_map_position(packet: Packet) -> Option<Position> {
 }
 
 #[derive(Debug, Clone)]
-struct Patchwork {
-    pub maps: Vec<Map>,
-    pub player_map_indexes: HashMap::<Uuid, usize>
+struct Anchor {
+    map_index: usize,
+    conn_id: Option<Uuid>,
 }
 
+impl Anchor {
+    pub fn connect(
+        peer: Peer,
+        map_index: usize,
+        messenger: Sender<MessengerOperations>,
+    ) -> Result<Anchor, io::Error> {
+        println!("would connect to peer {:?}", peer.clone());
+        let conn_id = Uuid::new_v4();
+        let stream = server::new_connection(peer.address.clone(), peer.port)?;
+        messenger
+            .send(MessengerOperations::New(NewConnectionMessage {
+                conn_id,
+                socket: stream.try_clone().unwrap(),
+            }))
+            .unwrap();
+        send_packet!(
+            messenger,
+            conn_id,
+            Packet::Handshake(packet::Handshake {
+                protocol_version: 404,
+                server_address: String::from(""), //Neither of these fields are actually used
+                server_port: 0,
+                next_state: 4,
+            })
+        )
+        .unwrap();
+        send_packet!(
+            messenger,
+            conn_id,
+            Packet::Handshake(packet::Handshake {
+                protocol_version: 404,
+                server_address: String::from(""), //Neither of these fields are actually used
+                server_port: 0,
+                next_state: 4,
+            })
+        )
+        .unwrap();
+        Ok(Anchor {
+            map_index,
+            conn_id: Some(conn_id),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Patchwork {
+    pub maps: Vec<Map>,
+    pub player_anchors: HashMap<Uuid, Anchor>,
+}
 
 impl Patchwork {
     pub fn new() -> Patchwork {
-        let mut patchwork = Patchwork { maps: Vec::new(), player_map_indexes: HashMap::new() };
+        let mut patchwork = Patchwork {
+            maps: Vec::new(),
+            player_anchors: HashMap::new(),
+        };
         patchwork.create_local_map();
         patchwork
     }

--- a/src/game_state/player.rs
+++ b/src/game_state/player.rs
@@ -86,6 +86,20 @@ fn handle_message(
                 Packet::ClientboundPlayerPositionAndLook(player.pos_and_look_packet())
             )
             .unwrap();
+            broadcast_packet!(
+                messenger,
+                Packet::PlayerInfo(player.player_info_packet()),
+                Some(msg.conn_id),
+                true
+            )
+            .unwrap();
+            broadcast_packet!(
+                messenger,
+                Packet::SpawnPlayer(player.spawn_player_packet()),
+                Some(msg.conn_id),
+                true
+            )
+            .unwrap();
             players.insert(msg.conn_id, player);
         }
         PlayerStateOperations::MoveAndLook(msg) => {

--- a/src/initiation_protocols/border_cross_login.rs
+++ b/src/initiation_protocols/border_cross_login.rs
@@ -1,9 +1,44 @@
 #![allow(unused)] // removing warnings for now since this is not implemented yet
 
+use super::game_state::block;
+use super::game_state::block::BlockStateOperations;
+use super::game_state::patchwork::PatchworkStateOperations;
+use super::game_state::player;
+use super::game_state::player::{Angle, NewPlayerMessage, Player, PlayerStateOperations, Position};
+use super::messenger::{MessengerOperations, SendPacketMessage, SubscribeMessage, SubscriberType};
 use super::packet;
-use super::packet::{read, write, Packet};
+use super::packet::Packet;
+use std::sync::mpsc::Sender;
+use uuid::Uuid;
 
 // Called by the server when a new player is walking in its map
-pub fn init_border_cross_login(p: Packet) {
-    unimplemented!("TODO");
+pub fn init_border_cross_login(
+    p: Packet,
+    conn_id: Uuid,
+    messenger: Sender<MessengerOperations>,
+    player_state: Sender<PlayerStateOperations>,
+) {
+    let player = Player {
+        conn_id,
+        uuid: Uuid::new_v4(),
+        name: String::from("ghost"),
+        entity_id: 0, // replaced by player state
+        position: Position {
+            x: 5.0,
+            y: 16.0,
+            z: 5.0,
+        },
+        angle: Angle {
+            pitch: 0.0,
+            yaw: 0.0,
+        },
+    };
+
+    //update the gamestate with this new player
+    player_state
+        .send(PlayerStateOperations::New(NewPlayerMessage {
+            conn_id,
+            player,
+        }))
+        .unwrap();
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -23,6 +23,7 @@ pub struct Peer {
 
 #[derive(Debug, Clone)]
 pub struct RemoteMap {
+    pub peer: Peer,
     pub position: Position,
     pub entity_id_block: i32,
     pub conn_id: Uuid,
@@ -109,6 +110,7 @@ impl RemoteMap {
             );
         });
         let map = RemoteMap {
+            peer,
             position,
             entity_id_block,
             conn_id,
@@ -118,8 +120,8 @@ impl RemoteMap {
             conn_id,
             Packet::Handshake(Handshake {
                 protocol_version: 404,
-                server_address: peer.address.clone(),
-                server_port: peer.port,
+                server_address: String::from(""),
+                server_port: 0,
                 next_state: 6,
             })
         )
@@ -134,8 +136,8 @@ impl RemoteMap {
             conn_id,
             Packet::Handshake(Handshake {
                 protocol_version: 404,
-                server_address: peer.address.clone(),
-                server_port: peer.port,
+                server_address: String::from(""),
+                server_port: 0,
                 next_state: 6,
             })
         )

--- a/src/packet_router.rs
+++ b/src/packet_router.rs
@@ -48,8 +48,8 @@ pub fn route_packet(
             TranslationUpdates::NoChange
         }
         Status::BorderCrossLogin => {
-            border_cross_login::init_border_cross_login(packet);
-            TranslationUpdates::NoChange
+            border_cross_login::init_border_cross_login(packet, conn_id, messenger, player_state);
+            TranslationUpdates::State(3)
         }
         Status::InPeerSub => {
             in_peer_sub::init_incoming_peer_sub(packet, conn_id, messenger);


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/70

### Why 
We need to spawn players on the other server when they cross the border. 
There was also a bug which caused new players to not see each other

### What
Spawn player when they cross the border
Broadcast player to users when a new player joins

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [ ] The output of cargo clippy is empty (this is a scrappy PR, not going to bother with this yet)
- [x] I have run cargo fmt on my most recent changes
- [x] I haven't read the PR template
