### PR TITLE
Forward Player packets over border

### DIFF
--- a/src/initiation_protocols/border_cross_login.rs
+++ b/src/initiation_protocols/border_cross_login.rs
@@ -17,28 +17,34 @@ pub fn init_border_cross_login(
     conn_id: Uuid,
     messenger: Sender<MessengerOperations>,
     player_state: Sender<PlayerStateOperations>,
-) {
-    let player = Player {
-        conn_id,
-        uuid: Uuid::new_v4(),
-        name: String::from("ghost"),
-        entity_id: 0, // replaced by player state
-        position: Position {
-            x: 5.0,
-            y: 16.0,
-            z: 5.0,
-        },
-        angle: Angle {
-            pitch: 0.0,
-            yaw: 0.0,
-        },
-    };
+) -> bool {
+    match p {
+        Packet::PlayerPositionAndLook(packet) => {
+            let player = Player {
+                conn_id,
+                uuid: Uuid::new_v4(),
+                name: String::from("ghost"),
+                entity_id: 0, // replaced by player state
+                position: Position {
+                    x: packet.x,
+                    y: packet.feet_y,
+                    z: packet.z,
+                },
+                angle: Angle {
+                    pitch: packet.pitch,
+                    yaw: packet.yaw,
+                },
+            };
 
-    //update the gamestate with this new player
-    player_state
-        .send(PlayerStateOperations::New(NewPlayerMessage {
-            conn_id,
-            player,
-        }))
-        .unwrap();
+            //update the gamestate with this new player
+            player_state
+                .send(PlayerStateOperations::New(NewPlayerMessage {
+                    conn_id,
+                    player,
+                }))
+                .unwrap();
+            true
+        }
+        _ => false,
+    }
 }

--- a/src/minecraft_protocol.rs
+++ b/src/minecraft_protocol.rs
@@ -15,6 +15,7 @@ pub trait MinecraftProtocolReader {
     fn read_u_128(&mut self) -> u128;
     fn read_int(&mut self) -> i32;
     fn read_int_array(&mut self, length: u32) -> Vec<i32>;
+    fn read_var_int_array(&mut self, length: u32) -> Vec<i32>;
     fn read_chunk_section(&mut self) -> ChunkSection;
     fn read_float(&mut self) -> f32;
     fn read_double(&mut self) -> f64;
@@ -32,6 +33,7 @@ pub trait MinecraftProtocolWriter {
     fn write_u_128(&mut self, v: u128);
     fn write_int(&mut self, v: i32);
     fn write_int_array(&mut self, v: Vec<i32>);
+    fn write_var_int_array(&mut self, v: Vec<i32>);
     fn write_chunk_section(&mut self, v: ChunkSection);
     fn write_float(&mut self, v: f32);
     fn write_double(&mut self, v: f64);
@@ -199,6 +201,14 @@ impl<T: Read> MinecraftProtocolReader for T {
         v
     }
 
+    fn read_var_int_array(&mut self, length: u32) -> Vec<i32> {
+        let mut v = Vec::<i32>::new();
+        for _ in 0..length {
+            v.push(self.read_var_int());
+        }
+        v
+    }
+
     fn read_float(&mut self) -> f32 {
         self.read_f32::<BigEndian>().unwrap()
     }
@@ -264,6 +274,10 @@ impl<T: Write> MinecraftProtocolWriter for T {
     fn write_int_array(&mut self, v: Vec<i32>) {
         v.iter()
             .for_each(|element| self.write_i32::<BigEndian>(*element).unwrap());
+    }
+
+    fn write_var_int_array(&mut self, v: Vec<i32>) {
+        v.iter().for_each(|element| self.write_var_int(*element));
     }
 
     fn write_chunk_section(&mut self, v: ChunkSection) {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -24,24 +24,24 @@ packet_boilerplate!(
     (1, StatusRequest, 0, []),
     (1, Ping, 1, [(payload, Long)]),
     (2, LoginStart, 0, [(username, String)]),
-    (3, KeepAlive, 0x21, [(id, Long)]),
+    (_, KeepAlive, 0x21, [(id, Long)]),
     (
-        3,
+        _,
         PlayerPosition,
         0x10,
         [
-            (x, Double),
+            (x, Double, XEntity),
             (feet_y, Double),
             (z, Double),
             (on_ground, Boolean)
         ]
     ),
     (
-        3,
+        _,
         PlayerPositionAndLook,
         0x11,
         [
-            (x, Double),
+            (x, Double, XEntity),
             (feet_y, Double),
             (z, Double),
             (yaw, Float),
@@ -50,7 +50,7 @@ packet_boilerplate!(
         ]
     ),
     (
-        3,
+        _,
         PlayerLook,
         0x12,
         [
@@ -143,6 +143,14 @@ packet_boilerplate!(
         [
             (entity_id, VarInt, EntityId),
             (angle, UByte)
+        ]
+    ),
+    (
+        _,
+        DestroyEntities,
+        0x35,
+        [
+            (entity_ids, LengthPrefixedArray(VarInt))
         ]
     ),
     (

--- a/src/packet_router.rs
+++ b/src/packet_router.rs
@@ -48,8 +48,12 @@ pub fn route_packet(
             TranslationUpdates::NoChange
         }
         Status::BorderCrossLogin => {
-            border_cross_login::init_border_cross_login(packet, conn_id, messenger, player_state);
-            TranslationUpdates::State(3)
+            if border_cross_login::init_border_cross_login(packet, conn_id, messenger, player_state)
+            {
+                TranslationUpdates::State(3)
+            } else {
+                TranslationUpdates::NoChange
+            }
         }
         Status::InPeerSub => {
             in_peer_sub::init_incoming_peer_sub(packet, conn_id, messenger);


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/70

Buggy hacky implementation of border crossing. Some known issues I've put into tickets in the annotations

### Why 
In the prior implementation of this we were just spawning the ghost at a random position and not forwarding the packets of the local client to the peer. We want to have this ghost appear exactly as the player does to other players

### What
-Added outgoing translation data concept in messenger
-Update outgoing translation data from patchwork state
-Send position data to peer when border crossing
-Delete old entity when border crossing
-Moved some border crossing responsibility to player state
-Forward packets to peer after a client crosses the border
-Add var int arrays
-Add length prefixed array type
-Swallow any packets received during the border cross protocol to prevent crashes. Issue in annotations

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
