### PR TITLE
Remove unneeded parts of pattern hack

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -24,9 +24,9 @@ packet_boilerplate!(
     (1, StatusRequest, 0, []),
     (1, Ping, 1, [(payload, Long)]),
     (2, LoginStart, 0, [(username, String)]),
-    (_, KeepAlive, 0x21, [(id, Long)]),
+    (3, KeepAlive, 0x21, [(id, Long)]),
     (
-        _,
+        3,
         PlayerPosition,
         0x10,
         [
@@ -37,7 +37,7 @@ packet_boilerplate!(
         ]
     ),
     (
-        _,
+        _, //Temporary for border crossing, once it has its own packet change this back to 3
         PlayerPositionAndLook,
         0x11,
         [
@@ -50,7 +50,7 @@ packet_boilerplate!(
         ]
     ),
     (
-        _,
+        3,
         PlayerLook,
         0x12,
         [


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/86

### Why
For consistency, we should try to keep the reading stateful for play packets. So since we can't have all play packets match on '_' (since there is id overlap with other states), they should all match on state 3.

### What
Changed all the ones that aren't blocked. One is blocked on this blocked issue: https://github.com/DuncanUszkay1/Patchwork/issues/86

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
