### PR TITLE
Move translation updates into packet handler layer

### DIFF
--- a/src/packet_handlers.rs
+++ b/src/packet_handlers.rs
@@ -11,3 +11,4 @@ pub mod peer_subscription;
 use super::game_state;
 use super::messenger;
 use super::packet;
+use super::translation::TranslationUpdates;

--- a/src/packet_handlers/initiation_protocols.rs
+++ b/src/packet_handlers/initiation_protocols.rs
@@ -13,3 +13,4 @@ pub mod login;
 use super::game_state;
 use super::messenger;
 use super::packet;
+use super::TranslationUpdates;

--- a/src/packet_handlers/initiation_protocols/border_cross_login.rs
+++ b/src/packet_handlers/initiation_protocols/border_cross_login.rs
@@ -8,6 +8,7 @@ use super::game_state::player::{Angle, NewPlayerMessage, Player, PlayerStateOper
 use super::messenger::{MessengerOperations, SendPacketMessage, SubscribeMessage, SubscriberType};
 use super::packet;
 use super::packet::Packet;
+use super::TranslationUpdates;
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
 
@@ -16,7 +17,7 @@ pub fn border_cross_login(
     conn_id: Uuid,
     messenger: Sender<MessengerOperations>,
     player_state: Sender<PlayerStateOperations>,
-) -> bool {
+) -> TranslationUpdates {
     match p {
         Packet::PlayerPositionAndLook(packet) => {
             let player = Player {
@@ -42,8 +43,8 @@ pub fn border_cross_login(
                     player,
                 }))
                 .unwrap();
-            true
+            TranslationUpdates::State(3)
         }
-        _ => false,
+        _ => TranslationUpdates::NoChange,
     }
 }

--- a/src/packet_handlers/initiation_protocols/client_ping.rs
+++ b/src/packet_handlers/initiation_protocols/client_ping.rs
@@ -1,13 +1,18 @@
 use super::messenger::{MessengerOperations, SendPacketMessage};
 use super::packet;
 use super::packet::Packet;
+use super::TranslationUpdates;
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
 
 const FAKE_RESPONSE: &str = "{\"version\": {\"name\": \"1.13.2\",\"protocol\": 404},\"players\": {\"max\": 100,\"online\": 5,\"sample\": [{\"name\": \"thinkofdeath\",\"id\": \"4566e69f-c907-48ee-8d71-d7ba5aa00d20\"}]},\"description\": {\"text\": \"Hello world\"},\"favicon\": \"data:image/png;base64,<data>\"}";
 
 // Called when client pings the server
-pub fn init_client_ping(p: Packet, conn_id: Uuid, messenger: Sender<MessengerOperations>) {
+pub fn handle_client_ping_packet(
+    p: Packet,
+    conn_id: Uuid,
+    messenger: Sender<MessengerOperations>,
+) -> TranslationUpdates {
     match p.clone() {
         Packet::StatusRequest(_) => {
             let status_response = packet::StatusResponse {
@@ -24,4 +29,5 @@ pub fn init_client_ping(p: Packet, conn_id: Uuid, messenger: Sender<MessengerOpe
         }
         _ => {}
     }
+    TranslationUpdates::NoChange
 }

--- a/src/packet_handlers/initiation_protocols/handshake.rs
+++ b/src/packet_handlers/initiation_protocols/handshake.rs
@@ -1,9 +1,10 @@
 use super::packet::Packet;
+use super::TranslationUpdates;
 
 // Called upon handshake
-pub fn init_handshake(p: Packet) -> i32 {
-    match p.clone() {
+pub fn handle_handshake_packet(p: Packet) -> TranslationUpdates {
+    TranslationUpdates::State(match p.clone() {
         Packet::Handshake(handshake) => handshake.next_state,
         _ => panic!("Invalid packet {:?}", p),
-    }
+    })
 }

--- a/src/packet_handlers/initiation_protocols/login.rs
+++ b/src/packet_handlers/initiation_protocols/login.rs
@@ -6,18 +6,18 @@ use super::game_state::player::{Angle, NewPlayerMessage, Player, PlayerStateOper
 use super::messenger::{MessengerOperations, SendPacketMessage, SubscribeMessage, SubscriberType};
 use super::packet;
 use super::packet::Packet;
+use super::TranslationUpdates;
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
 
-// Called upon user login
-pub fn init_login(
+pub fn handle_login_packet(
     p: Packet,
     conn_id: Uuid,
     messenger: Sender<MessengerOperations>,
     player_state: Sender<PlayerStateOperations>,
     block_state: Sender<BlockStateOperations>,
     patchwork_state: Sender<PatchworkStateOperations>,
-) {
+) -> TranslationUpdates {
     match p.clone() {
         Packet::LoginStart(login_start) => {
             confirm_login(
@@ -28,6 +28,7 @@ pub fn init_login(
                 block_state,
                 patchwork_state,
             );
+            TranslationUpdates::State(3)
         }
         _ => {
             panic!("Login failed");
@@ -83,8 +84,6 @@ fn confirm_login(
         }))
         .unwrap();
 
-    //report current state to player (soon to be in it's own component for reuse)
-    //the only state we keep right now is players
     player_state
         .send(PlayerStateOperations::Report(player::ReportMessage {
             conn_id,


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/91

### Why
Having the packet router determine the changes to the translation info was making it too knowledgable

### What
Changed initiation protocols to return translation updates. Left the non-initiation protocol packet handlers as they were, since there wasn't a terribly clean way to move translation information into the gameplay router. I think this will be fine for now

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
