### PR TITLE
Remove allow unused flag for border crossing

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,5 +1,5 @@
 #![allow(unused_variables)]
-//Had to disable unused variables here since it wasn't working with packet::new
+//The macro is much cleaner if we allow for unused variables
 use super::game_state::patchwork::{CHUNK_SIZE, ENTITY_ID_BLOCK_SIZE};
 use super::minecraft_protocol::{
     write_var_int, ChunkSection, MinecraftProtocolReader, MinecraftProtocolWriter,

--- a/src/packet_handlers/initiation_protocols/border_cross_login.rs
+++ b/src/packet_handlers/initiation_protocols/border_cross_login.rs
@@ -1,12 +1,4 @@
-#![allow(unused)] // removing warnings for now since this is not implemented yet
-
-use super::game_state::block;
-use super::game_state::block::BlockStateOperations;
-use super::game_state::patchwork::PatchworkStateOperations;
-use super::game_state::player;
 use super::game_state::player::{Angle, NewPlayerMessage, Player, PlayerStateOperations, Position};
-use super::messenger::{MessengerOperations, SendPacketMessage, SubscribeMessage, SubscriberType};
-use super::packet;
 use super::packet::Packet;
 use super::TranslationUpdates;
 use std::sync::mpsc::Sender;
@@ -15,7 +7,6 @@ use uuid::Uuid;
 pub fn border_cross_login(
     p: Packet,
     conn_id: Uuid,
-    messenger: Sender<MessengerOperations>,
     player_state: Sender<PlayerStateOperations>,
 ) -> TranslationUpdates {
     match p {

--- a/src/packet_router.rs
+++ b/src/packet_router.rs
@@ -43,7 +43,7 @@ pub fn route_packet(
             TranslationUpdates::NoChange
         }
         Status::BorderCrossLogin => {
-            border_cross_login::border_cross_login(packet, conn_id, messenger, player_state)
+            border_cross_login::border_cross_login(packet, conn_id, player_state)
         }
         Status::InPeerSub => {
             peer_subscription::handle_peer_packet(packet, messenger);


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/88

### Why
We should avoid clippy flags wherever possible

### What
Removed the clippy flag for the border crossing protocol. Decided to keep it in for the packets, since fixing that for the macro would be a hassle. Specifically because depending on the packet the translation data may or may not be unused.

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
