### PR TITLE
Refactor some dependencies

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,20 +4,9 @@ mod models;
 mod packet_handlers;
 mod server;
 
-use game_state::patchwork::{NewMapMessage, PatchworkStateOperations};
+use services::game_state::patchwork::{NewMapMessage, PatchworkStateOperations};
 
-use packet_handlers::packet_router;
-
-use models::map;
-use models::minecraft_types;
-use models::packet;
-use models::translation;
-
-use services::game_state;
 use services::instance::ServiceInstance;
-use services::keep_alive;
-use services::messenger;
-use services::packet_processor;
 
 use std::env;
 use std::thread;
@@ -44,32 +33,32 @@ fn main() {
 
     define_services!(
         (
-            module: game_state::player::start,
+            module: services::game_state::player::start,
             name: player_state,
             dependencies: [messenger]
         ),
         (
-            module: game_state::block::start,
+            module: services::game_state::block::start,
             name: block_state,
             dependencies: [messenger]
         ),
         (
-            module: game_state::patchwork::start,
+            module: services::game_state::patchwork::start,
             name: patchwork_state,
             dependencies: [messenger, inbound_packet_processor, player_state]
         ),
         (
-            module: messenger::start,
+            module: services::messenger::start,
             name: messenger,
             dependencies: []
         ),
         (
-            module: packet_processor::start_inbound,
+            module: services::packet_processor::start_inbound,
             name: inbound_packet_processor,
             dependencies: [messenger, player_state, block_state, patchwork_state]
         ),
         (
-            module: keep_alive::start,
+            module: services::keep_alive::start,
             name: keep_alive,
             dependencies: [messenger]
         )
@@ -84,7 +73,7 @@ fn main() {
     patchwork_state
         .sender()
         .send(PatchworkStateOperations::New(NewMapMessage {
-            peer: map::Peer {
+            peer: models::map::Peer {
                 port: peer_port,
                 address: peer_address,
             },

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,12 +1,13 @@
 #[macro_use]
 mod packet_macros;
 pub mod map;
-mod minecraft_protocol;
+pub mod minecraft_protocol;
 pub mod minecraft_types;
 pub mod packet;
 pub mod translation;
 
-use super::game_state;
-use super::messenger;
-use super::packet_processor;
+use super::services::game_state;
+use super::services::messenger;
+use super::services::packet_processor;
+
 use super::server;

--- a/src/models/minecraft_protocol.rs
+++ b/src/models/minecraft_protocol.rs
@@ -1,9 +1,9 @@
 extern crate byteorder;
 
-use super::minecraft_types::{read_var_int, ChunkSection};
+use super::minecraft_types::ChunkSection;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::cmp::{max, min};
-use std::io::{Read, Write};
+use std::io::{Error, Read, Write};
 
 const PALETTE_SIZE: i64 = 14; // We don't define our own palette, so we just use the default all blocks palette which is 14 bits
 
@@ -11,6 +11,7 @@ pub trait MinecraftProtocolReader {
     fn read_unsigned_short(&mut self) -> u16;
     fn read_short(&mut self) -> i16;
     fn read_var_int(&mut self) -> i32;
+    fn try_read_var_int(&mut self) -> Result<i32, Error>;
     fn read_long(&mut self) -> i64;
     fn read_string(&mut self) -> String;
     fn read_u_128(&mut self) -> u128;
@@ -43,98 +44,17 @@ pub trait MinecraftProtocolWriter {
     fn write_boolean(&mut self, v: bool);
 }
 
-//We now have a functional though messy implementation of writing any block
-pub fn write_chunk_section<S: Write>(stream: &mut S, v: ChunkSection) {
-    stream.write_u_byte(v.bits_per_block);
-    stream.write_var_int(v.data_array_length);
-    let mut long: i64 = 0;
-    for i in 0..4096 {
-        let block_to_place = v.block_ids[i as usize] as i64;
-        let offset = (PALETTE_SIZE * i) % 64;
-        long += block_to_place << offset;
-        if ((i * PALETTE_SIZE) % 64) >= 64 - PALETTE_SIZE {
-            stream.write_long(long);
-            long = block_to_place >> (64 - offset);
-        }
-    }
-    for _ in 0..2048 {
-        stream
-            .write_u8(!0b0)
-            .expect("could not write max block light"); //write max block light
-    }
-    for _ in 0..2048 {
-        stream
-            .write_u8(!0b0)
-            .expect("could not write max sky light"); //write max sky light
-    }
-}
-
-pub fn read_chunk_section<S: Read>(stream: &mut S) -> ChunkSection {
-    let bits_per_block = stream.read_u_byte();
-    if bits_per_block != PALETTE_SIZE as u8 {
-        panic!("Cannot read palettes");
-    }
-    let data_array_length = stream.read_var_int();
-    if data_array_length != 896 {
-        panic!("Got unexpected data array length");
-    }
-    let mut block_ids = Vec::<i32>::new();
-    let mut long = stream.read_u64::<BigEndian>().unwrap();
-    let mut index = 0;
-    for i in 0..4096 {
-        let bits_to_read = min(64 - (index % 64), 14);
-        let left_shift = max(64 - (bits_to_read + (index % 64)), 0);
-        let right_shift = left_shift + (index % 64);
-        let mut block_id = (long << left_shift) >> right_shift;
-        if left_shift == 0 && i != 4095 {
-            long = stream.read_u64::<BigEndian>().unwrap();
-        }
-        if bits_to_read < 14 {
-            let remainder_to_read = 14 - bits_to_read;
-            let remainder = long << (64 - remainder_to_read) >> (64 - remainder_to_read);
-            block_id += remainder >> remainder_to_read;
-        };
-        block_ids.push(block_id as i32);
-        index += 14;
-    }
-    //Still ignoring these values for now
-    for _ in 0..2048 {
-        stream.read_u8().unwrap();
-    }
-    for _ in 0..2048 {
-        stream.read_u8().unwrap();
-    }
-    ChunkSection {
-        bits_per_block,
-        data_array_length,
-        block_ids,
-        block_light: Vec::<u64>::new(),
-        sky_light: Vec::<u64>::new(),
-    }
-}
-
-pub fn write_var_int<S: Write>(stream: &mut S, v: i32) {
-    let mut value = v;
-    loop {
-        let mut temp = value & 0b0111_1111;
-        value >>= 7;
-        if value != 0 {
-            temp |= 0b1000_0000;
-        }
-        stream.write_u8(temp as u8).unwrap();
-        if value == 0 {
-            break;
-        }
-    }
-}
-
 impl<T: Read> MinecraftProtocolReader for T {
     fn read_long(&mut self) -> i64 {
         self.read_i64::<BigEndian>().unwrap()
     }
 
     fn read_var_int(&mut self) -> i32 {
-        read_var_int(self).unwrap()
+        self.try_read_var_int().unwrap()
+    }
+
+    fn try_read_var_int(&mut self) -> Result<i32, Error> {
+        read_var_int(self)
     }
 
     fn read_unsigned_short(&mut self) -> u16 {
@@ -275,5 +195,109 @@ impl<T: Write> MinecraftProtocolWriter for T {
         } else {
             self.write_u8(0).unwrap()
         }
+    }
+}
+
+fn read_var_int<S: Read>(stream: &mut S) -> Result<i32, Error> {
+    let mut num_read = 0;
+    let mut result: i32 = 0;
+
+    loop {
+        let value = i32::from(stream.read_u8()?);
+        result |= (value & 0b0111_1111) << (7 * num_read);
+        num_read += 1;
+        if num_read > 5 {
+            panic!("VarInt is too big");
+        }
+        if (value & 0b1000_0000) == 0 {
+            break;
+        }
+    }
+
+    Ok(result)
+}
+
+fn write_var_int<S: Write>(stream: &mut S, v: i32) {
+    let mut value = v;
+    loop {
+        let mut temp = value & 0b0111_1111;
+        value >>= 7;
+        if value != 0 {
+            temp |= 0b1000_0000;
+        }
+        stream.write_u8(temp as u8).unwrap();
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+//We now have a functional though messy implementation of writing any block
+fn write_chunk_section<S: Write>(stream: &mut S, v: ChunkSection) {
+    stream.write_u_byte(v.bits_per_block);
+    stream.write_var_int(v.data_array_length);
+    let mut long: i64 = 0;
+    for i in 0..4096 {
+        let block_to_place = v.block_ids[i as usize] as i64;
+        let offset = (PALETTE_SIZE * i) % 64;
+        long += block_to_place << offset;
+        if ((i * PALETTE_SIZE) % 64) >= 64 - PALETTE_SIZE {
+            stream.write_long(long);
+            long = block_to_place >> (64 - offset);
+        }
+    }
+    for _ in 0..2048 {
+        stream
+            .write_u8(!0b0)
+            .expect("could not write max block light"); //write max block light
+    }
+    for _ in 0..2048 {
+        stream
+            .write_u8(!0b0)
+            .expect("could not write max sky light"); //write max sky light
+    }
+}
+
+fn read_chunk_section<S: Read>(stream: &mut S) -> ChunkSection {
+    let bits_per_block = stream.read_u_byte();
+    if bits_per_block != PALETTE_SIZE as u8 {
+        panic!("Cannot read palettes");
+    }
+    let data_array_length = stream.read_var_int();
+    if data_array_length != 896 {
+        panic!("Got unexpected data array length");
+    }
+    let mut block_ids = Vec::<i32>::new();
+    let mut long = stream.read_u64::<BigEndian>().unwrap();
+    let mut index = 0;
+    for i in 0..4096 {
+        let bits_to_read = min(64 - (index % 64), 14);
+        let left_shift = max(64 - (bits_to_read + (index % 64)), 0);
+        let right_shift = left_shift + (index % 64);
+        let mut block_id = (long << left_shift) >> right_shift;
+        if left_shift == 0 && i != 4095 {
+            long = stream.read_u64::<BigEndian>().unwrap();
+        }
+        if bits_to_read < 14 {
+            let remainder_to_read = 14 - bits_to_read;
+            let remainder = long << (64 - remainder_to_read) >> (64 - remainder_to_read);
+            block_id += remainder >> remainder_to_read;
+        };
+        block_ids.push(block_id as i32);
+        index += 14;
+    }
+    //Still ignoring these values for now
+    for _ in 0..2048 {
+        stream.read_u8().unwrap();
+    }
+    for _ in 0..2048 {
+        stream.read_u8().unwrap();
+    }
+    ChunkSection {
+        bits_per_block,
+        data_array_length,
+        block_ids,
+        block_light: Vec::<u64>::new(),
+        sky_light: Vec::<u64>::new(),
     }
 }

--- a/src/models/minecraft_types.rs
+++ b/src/models/minecraft_types.rs
@@ -1,29 +1,5 @@
-extern crate byteorder;
-
-use byteorder::ReadBytesExt;
-use std::io::{Error, Read};
-
 pub fn float_to_angle(f: f32) -> u8 {
     ((f / 360.0) * 256.0) as u8
-}
-
-pub fn read_var_int<S: Read>(stream: &mut S) -> Result<i32, Error> {
-    let mut num_read = 0;
-    let mut result: i32 = 0;
-
-    loop {
-        let value = i32::from(stream.read_u8()?);
-        result |= (value & 0b0111_1111) << (7 * num_read);
-        num_read += 1;
-        if num_read > 5 {
-            panic!("VarInt is too big");
-        }
-        if (value & 0b1000_0000) == 0 {
-            break;
-        }
-    }
-
-    Ok(result)
 }
 
 #[derive(Debug, Clone)]

--- a/src/models/packet.rs
+++ b/src/models/packet.rs
@@ -1,7 +1,7 @@
 #![allow(unused_variables)]
 //The macro is much cleaner if we allow for unused variables
 use super::game_state::patchwork::{CHUNK_SIZE, ENTITY_ID_BLOCK_SIZE};
-use super::minecraft_protocol::{write_var_int, MinecraftProtocolReader, MinecraftProtocolWriter};
+use super::minecraft_protocol::{MinecraftProtocolReader, MinecraftProtocolWriter};
 use super::minecraft_types::ChunkSection;
 use super::translation::TranslationInfo;
 use std::io::{Cursor, Read, Write};

--- a/src/models/packet_macros.rs
+++ b/src/models/packet_macros.rs
@@ -38,7 +38,7 @@ macro_rules! packet_boilerplate {
             let mut cursor = Cursor::new(Vec::new());
             match packet {
                 $(Packet::$name(packet) => {
-                    write_var_int(&mut cursor, $name::ID);
+                    cursor.write_var_int($name::ID);
                     packet.write_fields(&mut cursor)
                 })*
                 _ => { panic!("I don't know how to write this packet {:?}", packet) }
@@ -50,7 +50,7 @@ macro_rules! packet_boilerplate {
 
             //Write the length into a vector
             cursor = Cursor::new(Vec::new());
-            write_var_int(&mut cursor, size as i32);
+            cursor.write_var_int(size as i32);
 
             //combine the length vector with the sizing vector to get
             //the full byte vector of the packet

--- a/src/packet_handlers.rs
+++ b/src/packet_handlers.rs
@@ -9,8 +9,8 @@ pub mod initiation_protocols;
 pub mod packet_router;
 pub mod peer_subscription;
 
-use super::game_state;
-use super::messenger;
-use super::packet;
-use super::translation;
-use super::translation::TranslationUpdates;
+use super::services::game_state;
+use super::services::messenger;
+
+use super::models::packet;
+use super::models::translation;

--- a/src/packet_handlers/initiation_protocols.rs
+++ b/src/packet_handlers/initiation_protocols.rs
@@ -13,4 +13,4 @@ pub mod login;
 use super::game_state;
 use super::messenger;
 use super::packet;
-use super::TranslationUpdates;
+use super::translation;

--- a/src/packet_handlers/initiation_protocols/border_cross_login.rs
+++ b/src/packet_handlers/initiation_protocols/border_cross_login.rs
@@ -1,6 +1,6 @@
 use super::game_state::player::{Angle, NewPlayerMessage, Player, PlayerStateOperations, Position};
 use super::packet::Packet;
-use super::TranslationUpdates;
+use super::translation::TranslationUpdates;
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
 

--- a/src/packet_handlers/initiation_protocols/client_ping.rs
+++ b/src/packet_handlers/initiation_protocols/client_ping.rs
@@ -1,7 +1,7 @@
 use super::messenger::{MessengerOperations, SendPacketMessage};
 use super::packet;
 use super::packet::Packet;
-use super::TranslationUpdates;
+use super::translation::TranslationUpdates;
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
 

--- a/src/packet_handlers/initiation_protocols/handshake.rs
+++ b/src/packet_handlers/initiation_protocols/handshake.rs
@@ -1,5 +1,5 @@
 use super::packet::Packet;
-use super::TranslationUpdates;
+use super::translation::TranslationUpdates;
 
 // Called upon handshake
 pub fn handle_handshake_packet(p: Packet) -> TranslationUpdates {

--- a/src/packet_handlers/initiation_protocols/login.rs
+++ b/src/packet_handlers/initiation_protocols/login.rs
@@ -6,7 +6,7 @@ use super::game_state::player::{Angle, NewPlayerMessage, Player, PlayerStateOper
 use super::messenger::{MessengerOperations, SendPacketMessage, SubscribeMessage, SubscriberType};
 use super::packet;
 use super::packet::Packet;
-use super::TranslationUpdates;
+use super::translation::TranslationUpdates;
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
 

--- a/src/services.rs
+++ b/src/services.rs
@@ -11,10 +11,13 @@ pub mod game_state;
 pub mod keep_alive;
 pub mod packet_processor;
 
-use super::map;
-use super::minecraft_types;
-use super::packet;
+use super::models::map;
+use super::models::minecraft_types;
+use super::models::packet;
+use super::models::translation;
+
 use super::packet_handlers;
-use super::packet_router;
+
+use super::packet_handlers::packet_router;
+
 use super::server;
-use super::translation;


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/99

### Why
There were some odd dependencies being passed around that didn't need to be. We were importing everything into main, when we should really be importing them in the submodule that needs them to make it clear how the submodules depend on each other.

### What
- Moved some methods that were moved into minecraft_types back into minecraft protocol, which is now the official place for anything involving reading/writing data with respect to the minecraft protocol
- All reading/writing is done through the Reader/Writer traits instead of using the methods directly

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
