### PR TITLE
Make anchoring work via entity id allocation

### DIFF
--- a/src/models/packet_macros.rs
+++ b/src/models/packet_macros.rs
@@ -288,9 +288,16 @@ macro_rules! translate_incoming_packet_field {
     ($value:expr, $transdata:expr) => {
         $value
     };
-    ($value:expr, $transdata:expr, EntityId) => {
-        $value + ($transdata.map.entity_id_block * ENTITY_ID_BLOCK_SIZE)
-    };
+    ($value:expr, $transdata:expr, EntityId) => {{
+        //For now this is hardcoded to assume that the block of anchor ids associated to our
+        //server is 950 to 1000. Later, in settings with three servers, we will need to
+        //determine this range when initially setting up the connection to the peer
+        if $value % ENTITY_ID_BLOCK_SIZE >= 950 {
+            ($value % 1000) - 950
+        } else {
+            $value + ($transdata.map.entity_id_block * ENTITY_ID_BLOCK_SIZE)
+        }
+    }};
     ($value:expr, $transdata:expr, XChunk) => {
         $transdata.map.position.x
     };

--- a/src/packet_handlers/initiation_protocols/border_cross_login.rs
+++ b/src/packet_handlers/initiation_protocols/border_cross_login.rs
@@ -15,7 +15,10 @@ pub fn border_cross_login(
                 conn_id,
                 uuid: Uuid::new_v4(),
                 name: String::from("ghost"),
-                entity_id: 0, // replaced by player state
+                // hard coded to only work for the first player to login
+                // need to augment this packet to include the entity id on the host peer for this
+                // to work
+                entity_id: 950,
                 position: Position {
                     x: packet.x,
                     y: packet.feet_y,

--- a/src/packet_handlers/packet_router.rs
+++ b/src/packet_handlers/packet_router.rs
@@ -44,7 +44,7 @@ pub fn route_packet(
             border_cross_login::border_cross_login(packet, conn_id, player_state)
         }
         Status::InPeerSub => {
-            peer_subscription::handle_peer_packet(packet, messenger);
+            peer_subscription::handle_peer_packet(packet, messenger, player_state);
             TranslationUpdates::NoChange
         }
         Status::OutPeerSub => {


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/70

### Why
The previous implementation of anchors had a fatal flaw- the player who crossed the border would start hearing about its own events, which would cause it to think there was another player with an identical position to them doing identical things.

### What
Using an allocation method that lets us use the same entity without any visual bugs. Since it's important I'm going to do a writeup of the way it works in the wiki rather than write it out here.

Very much hardcoded and limited right now, needs a lot of work before it's good for anything past a demo.

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
