### PR TITLE
Add extra tracing logs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::thread;
 #[macro_use]
 extern crate log;
 extern crate simplelog;
-use simplelog::{Config, LevelFilter, SimpleLogger};
+use simplelog::{ConfigBuilder, LevelFilter, SimpleLogger};
 
 const DEFAULT_LOGGING_LEVEL: LevelFilter = LevelFilter::Info;
 
@@ -29,7 +29,13 @@ fn main() {
         Err(_) => DEFAULT_LOGGING_LEVEL,
     };
 
-    SimpleLogger::init(level, Config::default()).unwrap();
+    let logger_config = ConfigBuilder::new()
+        .set_max_level(LevelFilter::Off)
+        .set_thread_level(LevelFilter::Off)
+        .set_target_level(LevelFilter::Off)
+        .build();
+
+    SimpleLogger::init(level, logger_config).unwrap();
 
     define_services!(
         (

--- a/src/models/packet.rs
+++ b/src/models/packet.rs
@@ -4,6 +4,7 @@ use super::game_state::patchwork::{CHUNK_SIZE, ENTITY_ID_BLOCK_SIZE};
 use super::minecraft_protocol::{MinecraftProtocolReader, MinecraftProtocolWriter};
 use super::minecraft_types::ChunkSection;
 use super::translation::TranslationInfo;
+use std::any::type_name;
 use std::io::{Cursor, Read, Write};
 
 // Format: (state (99 is outgoing), name, id, [ list of (field name, field type) ]

--- a/src/models/packet_macros.rs
+++ b/src/models/packet_macros.rs
@@ -10,6 +10,16 @@ macro_rules! packet_boilerplate {
             $($name($name)),*
         }
 
+        impl<'a> Packet {
+            //Only used for debugging purposes
+            pub fn debug_print_type(&self) -> &'a str {
+                match self {
+                    $(Packet::$name(_) => type_name::<$name>()),*,
+                    Packet::Unknown => "Unknown"
+                }
+            }
+        }
+
         pub fn read<S: MinecraftProtocolReader + Read>(stream: &mut S, state: i32) -> Packet {
             let id = stream.read_var_int();
 

--- a/src/services/game_state/block.rs
+++ b/src/services/game_state/block.rs
@@ -39,6 +39,7 @@ pub fn start(receiver: Receiver<BlockStateOperations>, messenger: Sender<Messeng
     while let Ok(msg) = receiver.recv() {
         match msg {
             BlockStateOperations::Report(msg) => {
+                trace!("Reporting block state to {:?}", msg.conn_id);
                 //Just send a hardcoded simple chunk pillar
                 let mut block_ids = Vec::new();
                 fill_dummy_block_ids(&mut block_ids);

--- a/src/services/game_state/patchwork.rs
+++ b/src/services/game_state/patchwork.rs
@@ -44,11 +44,14 @@ pub fn start(
 
     while let Ok(msg) = receiver.recv() {
         match msg {
-            PatchworkStateOperations::New(msg) => patchwork.add_peer_map(
-                msg.peer,
-                messenger.clone(),
-                inbound_packet_processor.clone(),
-            ),
+            PatchworkStateOperations::New(msg) => {
+                trace!("Adding Peer Map for peer {:?}", msg.peer);
+                patchwork.add_peer_map(
+                    msg.peer,
+                    messenger.clone(),
+                    inbound_packet_processor.clone(),
+                )
+            }
             PatchworkStateOperations::RoutePlayerPacket(msg) => {
                 let patchwork_clone = patchwork.clone();
                 let anchor = patchwork
@@ -82,10 +85,15 @@ pub fn start(
                     Some(_) => match msg.packet {
                         Packet::Unknown => {}
                         _ => {
+                            trace!(
+                                "Routing packet from conn_id {:?} through anchor",
+                                msg.conn_id
+                            );
                             send_packet!(messenger, anchor.conn_id.unwrap(), msg.packet).unwrap();
                         }
                     },
                     None => {
+                        trace!("Routing packet from conn_id {:?} locally", msg.conn_id);
                         gameplay_router::route_packet(
                             msg.packet,
                             msg.conn_id,
@@ -95,6 +103,7 @@ pub fn start(
                 }
             }
             PatchworkStateOperations::Report => {
+                trace!("Reporting patchwork state");
                 patchwork.clone().report(messenger.clone());
             }
         }

--- a/src/services/messenger.rs
+++ b/src/services/messenger.rs
@@ -79,6 +79,11 @@ pub fn start(receiver: Receiver<MessengerOperations>) {
     while let Ok(msg) = receiver.recv() {
         match msg {
             MessengerOperations::Send(msg) => {
+                trace!(
+                    "Sending packet {:?} to conn_id {:?}",
+                    msg.packet.debug_print_type(),
+                    msg.conn_id
+                );
                 if let Some(socket) = connection_map.get(&msg.conn_id) {
                     let mut socket_clone = socket.try_clone().unwrap();
                     let translated_packet = match translation_data.get(&msg.conn_id) {
@@ -88,9 +93,25 @@ pub fn start(receiver: Receiver<MessengerOperations>) {
                         None => msg.packet,
                     };
                     write(&mut socket_clone, translated_packet);
+                    trace!("Send successful");
+                } else {
+                    trace!("Connection ID not found");
                 }
             }
             MessengerOperations::Broadcast(msg) => {
+                if msg.local {
+                    trace!(
+                        "Broadcasting packet {:?} from local source conn_id {:?}",
+                        msg.packet.debug_print_type(),
+                        msg.source_conn_id
+                    );
+                } else {
+                    trace!(
+                        "Broadcasting packet {:?} from remote source conn_id {:?}",
+                        msg.packet.debug_print_type(),
+                        msg.source_conn_id
+                    );
+                }
                 (&all_broadcast_list).iter().for_each(|conn_id| {
                     if msg.source_conn_id.is_none() || msg.source_conn_id.unwrap() != *conn_id {
                         if let Some(socket) = connection_map.get(&conn_id) {
@@ -110,18 +131,35 @@ pub fn start(receiver: Receiver<MessengerOperations>) {
                     });
                 }
             }
-            MessengerOperations::Subscribe(msg) => match msg.typ {
-                SubscriberType::All => {
-                    all_broadcast_list.insert(msg.conn_id);
+            MessengerOperations::Subscribe(msg) => {
+                trace!(
+                    "Subscribing conn_id {:?} with type {:?}",
+                    msg.conn_id,
+                    msg.typ
+                );
+                match msg.typ {
+                    SubscriberType::All => {
+                        all_broadcast_list.insert(msg.conn_id);
+                    }
+                    SubscriberType::LocalOnly => {
+                        local_only_broadcast_list.insert(msg.conn_id);
+                    }
                 }
-                SubscriberType::LocalOnly => {
-                    local_only_broadcast_list.insert(msg.conn_id);
-                }
-            },
+            }
             MessengerOperations::New(msg) => {
+                trace!(
+                    "New Connection with conn_id {:?} on socket {:?}",
+                    msg.conn_id,
+                    msg.socket
+                );
                 connection_map.insert(msg.conn_id, msg.socket);
             }
             MessengerOperations::UpdateTranslation(msg) => {
+                trace!(
+                    "Updating connection map for conn_id {:?} to {:?}",
+                    msg.conn_id,
+                    msg.map
+                );
                 translation_data.insert(
                     msg.conn_id,
                     TranslationInfo {


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/58

### Why
Even in tracing mode we weren't getting a lot of information on what was going on. Makes it hard to tell what's going on in the background

### What
Added logging lines in services, 1-2 log lines per message received to help make the flow more obvious

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
