### PR TITLE
Refactor messenger service to establish new syntax pattern

### DIFF
--- a/src/packet_handlers/initiation_protocols/client_ping.rs
+++ b/src/packet_handlers/initiation_protocols/client_ping.rs
@@ -1,17 +1,16 @@
-use super::messenger::{MessengerOperations, SendPacketMessage};
+use super::messenger::Messenger;
 use super::packet;
 use super::packet::Packet;
 use super::translation::TranslationUpdates;
-use std::sync::mpsc::Sender;
 use uuid::Uuid;
 
 const FAKE_RESPONSE: &str = "{\"version\": {\"name\": \"1.13.2\",\"protocol\": 404},\"players\": {\"max\": 100,\"online\": 5,\"sample\": [{\"name\": \"thinkofdeath\",\"id\": \"4566e69f-c907-48ee-8d71-d7ba5aa00d20\"}]},\"description\": {\"text\": \"Hello world\"},\"favicon\": \"data:image/png;base64,<data>\"}";
 
 // Called when client pings the server
-pub fn handle_client_ping_packet(
+pub fn handle_client_ping_packet<M: Messenger>(
     p: Packet,
     conn_id: Uuid,
-    messenger: Sender<MessengerOperations>,
+    messenger: M,
 ) -> TranslationUpdates {
     match p.clone() {
         Packet::StatusRequest(_) => {
@@ -19,13 +18,13 @@ pub fn handle_client_ping_packet(
                 json_response: String::from(FAKE_RESPONSE),
             };
 
-            send_packet!(messenger, conn_id, Packet::StatusResponse(status_response)).unwrap();
+            messenger.send_packet(conn_id, Packet::StatusResponse(status_response));
         }
         Packet::Ping(ping) => {
             let pong = packet::Pong {
                 payload: ping.payload,
             };
-            send_packet!(messenger, conn_id, Packet::Pong(pong)).unwrap();
+            messenger.send_packet(conn_id, Packet::Pong(pong));
         }
         _ => {}
     }

--- a/src/packet_handlers/packet_router.rs
+++ b/src/packet_handlers/packet_router.rs
@@ -2,7 +2,7 @@ use super::game_state::block::BlockStateOperations;
 use super::game_state::patchwork::{PatchworkStateOperations, RouteMessage};
 use super::game_state::player::PlayerStateOperations;
 use super::initiation_protocols::{border_cross_login, client_ping, handshake, login};
-use super::messenger::MessengerOperations;
+use super::messenger::Messenger;
 use super::packet::Packet;
 use super::peer_subscription;
 use super::translation::TranslationUpdates;
@@ -10,11 +10,11 @@ use std::sync::mpsc::Sender;
 use uuid::Uuid;
 
 // Routes the packet to the corresponding service according to the connection state
-pub fn route_packet(
+pub fn route_packet<M: Messenger + Clone>(
     packet: Packet,
     state: i32,
     conn_id: Uuid,
-    messenger: Sender<MessengerOperations>,
+    messenger: M,
     player_state: Sender<PlayerStateOperations>,
     block_state: Sender<BlockStateOperations>,
     patchwork_state: Sender<PatchworkStateOperations>,

--- a/src/services/keep_alive.rs
+++ b/src/services/keep_alive.rs
@@ -1,23 +1,21 @@
-use super::messenger::{BroadcastPacketMessage, MessengerOperations};
+use super::messenger::Messenger;
 use super::packet::{KeepAlive, Packet};
-use std::sync::mpsc::{Receiver, Sender};
+use std::sync::mpsc::Receiver;
 use std::thread::sleep;
 use std::time;
 
 const KEEP_ALIVE_PERIOD: u64 = 15;
 const KEEP_ALIVE_VALUE: i64 = 16;
 
-pub fn start(_: Receiver<i32>, messenger: Sender<MessengerOperations>) {
+pub fn start<M: Messenger>(_: Receiver<i32>, messenger: M) {
     loop {
         sleep(time::Duration::from_secs(KEEP_ALIVE_PERIOD));
-        broadcast_packet!(
-            messenger,
+        messenger.broadcast_packet(
             Packet::KeepAlive(KeepAlive {
-                id: KEEP_ALIVE_VALUE
+                id: KEEP_ALIVE_VALUE,
             }),
             None,
-            false
-        )
-        .unwrap();
+            false,
+        );
     }
 }

--- a/src/services/packet_processor.rs
+++ b/src/services/packet_processor.rs
@@ -1,7 +1,7 @@
 use super::game_state::block::BlockStateOperations;
 use super::game_state::patchwork::PatchworkStateOperations;
 use super::game_state::player::PlayerStateOperations;
-use super::messenger::MessengerOperations;
+use super::messenger::Messenger;
 use super::packet::{read, translate};
 use super::packet_router;
 use super::translation::{TranslationInfo, TranslationUpdates};
@@ -27,9 +27,9 @@ pub struct TranslationDataMessage {
     pub updates: Vec<TranslationUpdates>,
 }
 
-pub fn start_inbound(
+pub fn start_inbound<M: Messenger + Clone>(
     receiver: Receiver<PacketProcessorOperations>,
-    messenger: Sender<MessengerOperations>,
+    messenger: M,
     player_state: Sender<PlayerStateOperations>,
     block_state: Sender<BlockStateOperations>,
     patchwork_state: Sender<PatchworkStateOperations>,


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/108

### Why
There was a ton of boilerplate involved in calling a service, and knowledge of message structures. 

### What
Messages are much more friendly, let us make changes to the message structure without breaking anything, lets us avoid importing a ton of structs, and reduces boilerplate

Only did it for messenger, will follow up with the rest of the services

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
