### PR TITLE
Move all service interfaces into interfaces folder

### DIFF
--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -1,12 +1,9 @@
+pub mod block;
 pub mod messenger;
+pub mod packet_processor;
+pub mod patchwork;
+pub mod player;
 
 use super::models::map;
-use super::models::minecraft_types;
 use super::models::packet;
 use super::models::translation;
-
-use super::packet_handlers;
-
-use super::packet_handlers::packet_router;
-
-use super::server;

--- a/src/interfaces/block.rs
+++ b/src/interfaces/block.rs
@@ -1,0 +1,22 @@
+use std::sync::mpsc::Sender;
+use uuid::Uuid;
+
+pub trait BlockState {
+    fn report(&self, conn_id: Uuid);
+}
+
+impl BlockState for Sender<BlockStateOperations> {
+    fn report(&self, conn_id: Uuid) {
+        self.send(BlockStateOperations::Report(ReportMessage { conn_id }))
+            .unwrap();
+    }
+}
+
+pub enum BlockStateOperations {
+    Report(ReportMessage),
+}
+
+#[derive(Debug)]
+pub struct ReportMessage {
+    pub conn_id: Uuid,
+}

--- a/src/interfaces/packet_processor.rs
+++ b/src/interfaces/packet_processor.rs
@@ -1,0 +1,43 @@
+use super::translation::TranslationUpdates;
+
+use std::io::Cursor;
+use std::sync::mpsc::Sender;
+use uuid::Uuid;
+
+pub trait PacketProcessor {
+    fn inbound(&self, conn_id: Uuid, cursor: Cursor<Vec<u8>>);
+    fn set_translation_data(&self, conn_id: Uuid, updates: Vec<TranslationUpdates>);
+}
+
+impl PacketProcessor for Sender<PacketProcessorOperations> {
+    fn inbound(&self, conn_id: Uuid, cursor: Cursor<Vec<u8>>) {
+        self.send(PacketProcessorOperations::Inbound(InboundPacketMessage {
+            conn_id,
+            cursor,
+        }))
+        .unwrap()
+    }
+    fn set_translation_data(&self, conn_id: Uuid, updates: Vec<TranslationUpdates>) {
+        self.send(PacketProcessorOperations::SetTranslationData(
+            TranslationDataMessage { conn_id, updates },
+        ))
+        .unwrap();
+    }
+}
+
+pub enum PacketProcessorOperations {
+    Inbound(InboundPacketMessage),
+    SetTranslationData(TranslationDataMessage),
+}
+
+#[derive(Debug)]
+pub struct InboundPacketMessage {
+    pub conn_id: Uuid,
+    pub cursor: Cursor<Vec<u8>>,
+}
+
+#[derive(Debug)]
+pub struct TranslationDataMessage {
+    pub conn_id: Uuid,
+    pub updates: Vec<TranslationUpdates>,
+}

--- a/src/interfaces/patchwork.rs
+++ b/src/interfaces/patchwork.rs
@@ -1,0 +1,46 @@
+use super::map::Peer;
+use super::packet::Packet;
+use std::sync::mpsc::Sender;
+use uuid::Uuid;
+
+pub trait PatchworkState {
+    fn new_map(&self, peer: Peer);
+    fn route_player_packet(&self, packet: Packet, conn_id: Uuid);
+    fn report(&self);
+}
+
+impl PatchworkState for Sender<PatchworkStateOperations> {
+    fn new_map(&self, peer: Peer) {
+        self.send(PatchworkStateOperations::New(NewMapMessage { peer }))
+            .unwrap();
+    }
+
+    fn route_player_packet(&self, packet: Packet, conn_id: Uuid) {
+        self.send(PatchworkStateOperations::RoutePlayerPacket(RouteMessage {
+            packet,
+            conn_id,
+        }))
+        .unwrap();
+    }
+
+    fn report(&self) {
+        self.send(PatchworkStateOperations::Report).unwrap();
+    }
+}
+
+pub enum PatchworkStateOperations {
+    New(NewMapMessage),
+    RoutePlayerPacket(RouteMessage),
+    Report,
+}
+
+#[derive(Debug)]
+pub struct NewMapMessage {
+    pub peer: Peer,
+}
+
+#[derive(Debug, Clone)]
+pub struct RouteMessage {
+    pub packet: Packet,
+    pub conn_id: Uuid,
+}

--- a/src/interfaces/player.rs
+++ b/src/interfaces/player.rs
@@ -1,0 +1,119 @@
+use super::packet::Packet;
+use std::sync::mpsc::Sender;
+use uuid::Uuid;
+
+pub trait PlayerState {
+    fn new_player(&self, conn_id: Uuid, player: Player);
+    fn report(&self, conn_id: Uuid);
+    fn move_and_look(
+        &self,
+        conn_id: Uuid,
+        new_position: Option<Position>,
+        new_angle: Option<Angle>,
+    );
+    fn cross_border(&self, local_conn_id: Uuid, remote_conn_id: Uuid);
+    fn broadcast_anchored_event(&self, entity_id: i32, packet: Packet);
+}
+
+impl PlayerState for Sender<PlayerStateOperations> {
+    fn new_player(&self, conn_id: Uuid, player: Player) {
+        self.send(PlayerStateOperations::New(NewPlayerMessage {
+            conn_id,
+            player,
+        }))
+        .unwrap();
+    }
+    fn report(&self, conn_id: Uuid) {
+        self.send(PlayerStateOperations::Report(ReportMessage { conn_id }))
+            .unwrap();
+    }
+    fn move_and_look(
+        &self,
+        conn_id: Uuid,
+        new_position: Option<Position>,
+        new_angle: Option<Angle>,
+    ) {
+        self.send(PlayerStateOperations::MoveAndLook(
+            PlayerMoveAndLookMessage {
+                conn_id,
+                new_position,
+                new_angle,
+            },
+        ))
+        .unwrap();
+    }
+    fn cross_border(&self, local_conn_id: Uuid, remote_conn_id: Uuid) {
+        self.send(PlayerStateOperations::CrossBorder(CrossBorderMessage {
+            local_conn_id,
+            remote_conn_id,
+        }))
+        .unwrap();
+    }
+    fn broadcast_anchored_event(&self, entity_id: i32, packet: Packet) {
+        self.send(PlayerStateOperations::BroadcastAnchoredEvent(
+            BroadcastAnchoredEventMessage { entity_id, packet },
+        ))
+        .unwrap();
+    }
+}
+
+pub enum PlayerStateOperations {
+    New(NewPlayerMessage),
+    Report(ReportMessage),
+    MoveAndLook(PlayerMoveAndLookMessage),
+    CrossBorder(CrossBorderMessage),
+    BroadcastAnchoredEvent(BroadcastAnchoredEventMessage),
+}
+
+#[derive(Debug, Clone)]
+pub struct Player {
+    pub conn_id: Uuid,
+    pub uuid: Uuid,
+    pub name: String,
+    pub position: Position,
+    pub angle: Angle,
+    pub entity_id: i32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Position {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct Angle {
+    pub pitch: f32,
+    pub yaw: f32,
+}
+
+#[derive(Debug, Clone)]
+pub struct BroadcastAnchoredEventMessage {
+    pub entity_id: i32,
+    pub packet: Packet,
+}
+
+#[derive(Debug)]
+pub struct NewPlayerMessage {
+    pub conn_id: Uuid,
+    pub player: Player,
+}
+
+#[derive(Debug)]
+pub struct ReportMessage {
+    pub conn_id: Uuid,
+}
+
+#[derive(Debug)]
+pub struct CrossBorderMessage {
+    pub local_conn_id: Uuid,
+    pub remote_conn_id: Uuid,
+}
+
+#[derive(Debug)]
+pub struct PlayerMoveAndLookMessage {
+    pub conn_id: Uuid,
+    pub new_position: Option<Position>,
+    pub new_angle: Option<Angle>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod models;
 mod packet_handlers;
 mod server;
 
-use services::game_state::patchwork::PatchworkState;
+use interfaces::patchwork::PatchworkState;
 
 use services::instance::ServiceInstance;
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,7 +7,6 @@ pub mod packet;
 pub mod translation;
 
 use super::services::game_state;
-use super::services::packet_processor;
 
 use super::interfaces;
 use super::server;

--- a/src/models/map.rs
+++ b/src/models/map.rs
@@ -1,6 +1,6 @@
 use super::interfaces::messenger::Messenger;
+use super::interfaces::packet_processor::PacketProcessor;
 use super::packet::{Handshake, Packet};
-use super::packet_processor::PacketProcessor;
 use super::server;
 use super::translation::TranslationUpdates;
 use std::io;

--- a/src/packet_handlers.rs
+++ b/src/packet_handlers.rs
@@ -9,8 +9,6 @@ pub mod initiation_protocols;
 pub mod packet_router;
 pub mod peer_subscription;
 
-use super::services::game_state;
-
 use super::models::packet;
 use super::models::translation;
 

--- a/src/packet_handlers/gameplay_router.rs
+++ b/src/packet_handlers/gameplay_router.rs
@@ -1,4 +1,4 @@
-use super::game_state::player::{Angle, PlayerState, Position};
+use super::interfaces::player::{Angle, PlayerState, Position};
 use super::packet::Packet;
 use uuid::Uuid;
 

--- a/src/packet_handlers/initiation_protocols.rs
+++ b/src/packet_handlers/initiation_protocols.rs
@@ -10,7 +10,6 @@ pub mod client_ping;
 pub mod handshake;
 pub mod login;
 
-use super::game_state;
 use super::interfaces;
 use super::packet;
 use super::translation;

--- a/src/packet_handlers/initiation_protocols/border_cross_login.rs
+++ b/src/packet_handlers/initiation_protocols/border_cross_login.rs
@@ -1,4 +1,4 @@
-use super::game_state::player::{Angle, Player, PlayerState, Position};
+use super::interfaces::player::{Angle, Player, PlayerState, Position};
 use super::packet::Packet;
 use super::translation::TranslationUpdates;
 use uuid::Uuid;

--- a/src/packet_handlers/initiation_protocols/login.rs
+++ b/src/packet_handlers/initiation_protocols/login.rs
@@ -1,7 +1,7 @@
-use super::game_state::block::BlockState;
-use super::game_state::patchwork::PatchworkState;
-use super::game_state::player::{Angle, Player, PlayerState, Position};
+use super::interfaces::block::BlockState;
 use super::interfaces::messenger::{Messenger, SubscriberType};
+use super::interfaces::patchwork::PatchworkState;
+use super::interfaces::player::{Angle, Player, PlayerState, Position};
 use super::packet;
 use super::packet::Packet;
 use super::translation::TranslationUpdates;

--- a/src/packet_handlers/packet_router.rs
+++ b/src/packet_handlers/packet_router.rs
@@ -1,8 +1,9 @@
-use super::game_state::block::BlockState;
-use super::game_state::patchwork::PatchworkState;
-use super::game_state::player::PlayerState;
-use super::initiation_protocols::{border_cross_login, client_ping, handshake, login};
+use super::interfaces::block::BlockState;
 use super::interfaces::messenger::Messenger;
+use super::interfaces::patchwork::PatchworkState;
+use super::interfaces::player::PlayerState;
+
+use super::initiation_protocols::{border_cross_login, client_ping, handshake, login};
 use super::packet::Packet;
 use super::peer_subscription;
 use super::translation::TranslationUpdates;

--- a/src/packet_handlers/peer_subscription.rs
+++ b/src/packet_handlers/peer_subscription.rs
@@ -2,8 +2,8 @@ use super::interfaces::messenger::{Messenger, SubscriberType};
 use super::packet::Packet;
 use uuid::Uuid;
 
-use super::game_state::block::BlockState;
-use super::game_state::player::PlayerState;
+use super::interfaces::block::BlockState;
+use super::interfaces::player::PlayerState;
 
 pub fn handle_peer_packet<M: Messenger, P: PlayerState>(
     packet: Packet,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,5 @@
 use super::interfaces::messenger::Messenger;
-use super::services::packet_processor::PacketProcessor;
+use super::interfaces::packet_processor::PacketProcessor;
 
 use super::models::minecraft_protocol::MinecraftProtocolReader;
 

--- a/src/services.rs
+++ b/src/services.rs
@@ -17,9 +17,6 @@ use super::models::packet;
 use super::models::translation;
 
 use super::interfaces;
-
 use super::packet_handlers;
-
 use super::packet_handlers::packet_router;
-
 use super::server;

--- a/src/services/game_state.rs
+++ b/src/services/game_state.rs
@@ -7,5 +7,5 @@ use super::map;
 use super::minecraft_types;
 use super::packet;
 use super::packet_handlers::gameplay_router;
-use super::packet_processor;
+
 use super::server;

--- a/src/services/game_state/block.rs
+++ b/src/services/game_state/block.rs
@@ -1,33 +1,12 @@
+use super::interfaces::block::BlockStateOperations;
 use super::interfaces::messenger::Messenger;
 use super::minecraft_types::ChunkSection;
 use super::packet::{ChunkData, Packet};
 
-use std::sync::mpsc::{Receiver, Sender};
-use uuid::Uuid;
+use std::sync::mpsc::Receiver;
 
 // We don't really have any meaningful block state yet- it cannot be changed or be particularly
 // complicated. We can build this up later
-
-pub trait BlockState {
-    fn report(&self, conn_id: Uuid);
-}
-
-impl BlockState for Sender<BlockStateOperations> {
-    fn report(&self, conn_id: Uuid) {
-        self.send(BlockStateOperations::Report(ReportMessage { conn_id }))
-            .unwrap();
-    }
-}
-
-pub enum BlockStateOperations {
-    Report(ReportMessage),
-}
-
-#[derive(Debug)]
-pub struct ReportMessage {
-    pub conn_id: Uuid,
-}
-
 fn fill_dummy_block_ids(ids: &mut Vec<i32>) {
     while ids.len() < 4096 {
         let xz_pos = ids.len() % 256;

--- a/src/services/game_state/patchwork.rs
+++ b/src/services/game_state/patchwork.rs
@@ -1,61 +1,20 @@
 use super::gameplay_router;
 use super::interfaces::messenger::Messenger;
+use super::interfaces::packet_processor::PacketProcessor;
+use super::interfaces::patchwork::PatchworkStateOperations;
+use super::interfaces::player::PlayerState;
 use super::map::{Map, Peer, Position};
 use super::packet;
 use super::packet::Packet;
-use super::packet_processor::PacketProcessor;
-use super::player::PlayerState;
 use super::server;
 use std::collections::HashMap;
 use std::io;
 use std::sync::mpsc::Receiver;
-use std::sync::mpsc::Sender;
+
 use uuid::Uuid;
 
 pub const ENTITY_ID_BLOCK_SIZE: i32 = 1000;
 pub const CHUNK_SIZE: i32 = 16;
-
-pub trait PatchworkState {
-    fn new_map(&self, peer: Peer);
-    fn route_player_packet(&self, packet: Packet, conn_id: Uuid);
-    fn report(&self);
-}
-
-impl PatchworkState for Sender<PatchworkStateOperations> {
-    fn new_map(&self, peer: Peer) {
-        self.send(PatchworkStateOperations::New(NewMapMessage { peer }))
-            .unwrap();
-    }
-
-    fn route_player_packet(&self, packet: Packet, conn_id: Uuid) {
-        self.send(PatchworkStateOperations::RoutePlayerPacket(RouteMessage {
-            packet,
-            conn_id,
-        }))
-        .unwrap();
-    }
-
-    fn report(&self) {
-        self.send(PatchworkStateOperations::Report).unwrap();
-    }
-}
-
-pub enum PatchworkStateOperations {
-    New(NewMapMessage),
-    RoutePlayerPacket(RouteMessage),
-    Report,
-}
-
-#[derive(Debug)]
-pub struct NewMapMessage {
-    pub peer: Peer,
-}
-
-#[derive(Debug, Clone)]
-pub struct RouteMessage {
-    pub packet: Packet,
-    pub conn_id: Uuid,
-}
 
 pub fn start<
     M: 'static + Messenger + Clone + Send,

--- a/src/services/game_state/player.rs
+++ b/src/services/game_state/player.rs
@@ -1,4 +1,5 @@
 use super::interfaces::messenger::Messenger;
+use super::interfaces::player::{Angle, Player, PlayerStateOperations, Position};
 use super::minecraft_types::float_to_angle;
 use super::packet::{
     ClientboundPlayerPositionAndLook, EntityHeadLook, EntityLookAndMove, JoinGame, Packet,
@@ -6,124 +7,8 @@ use super::packet::{
 };
 use std::collections::HashMap;
 use std::convert::TryInto;
-use std::sync::mpsc::{Receiver, Sender};
+use std::sync::mpsc::Receiver;
 use uuid::Uuid;
-
-pub trait PlayerState {
-    fn new_player(&self, conn_id: Uuid, player: Player);
-    fn report(&self, conn_id: Uuid);
-    fn move_and_look(
-        &self,
-        conn_id: Uuid,
-        new_position: Option<Position>,
-        new_angle: Option<Angle>,
-    );
-    fn cross_border(&self, local_conn_id: Uuid, remote_conn_id: Uuid);
-    fn broadcast_anchored_event(&self, entity_id: i32, packet: Packet);
-}
-
-impl PlayerState for Sender<PlayerStateOperations> {
-    fn new_player(&self, conn_id: Uuid, player: Player) {
-        self.send(PlayerStateOperations::New(NewPlayerMessage {
-            conn_id,
-            player,
-        }))
-        .unwrap();
-    }
-    fn report(&self, conn_id: Uuid) {
-        self.send(PlayerStateOperations::Report(ReportMessage { conn_id }))
-            .unwrap();
-    }
-    fn move_and_look(
-        &self,
-        conn_id: Uuid,
-        new_position: Option<Position>,
-        new_angle: Option<Angle>,
-    ) {
-        self.send(PlayerStateOperations::MoveAndLook(
-            PlayerMoveAndLookMessage {
-                conn_id,
-                new_position,
-                new_angle,
-            },
-        ))
-        .unwrap();
-    }
-    fn cross_border(&self, local_conn_id: Uuid, remote_conn_id: Uuid) {
-        self.send(PlayerStateOperations::CrossBorder(CrossBorderMessage {
-            local_conn_id,
-            remote_conn_id,
-        }))
-        .unwrap();
-    }
-    fn broadcast_anchored_event(&self, entity_id: i32, packet: Packet) {
-        self.send(PlayerStateOperations::BroadcastAnchoredEvent(
-            BroadcastAnchoredEventMessage { entity_id, packet },
-        ))
-        .unwrap();
-    }
-}
-
-pub enum PlayerStateOperations {
-    New(NewPlayerMessage),
-    Report(ReportMessage),
-    MoveAndLook(PlayerMoveAndLookMessage),
-    CrossBorder(CrossBorderMessage),
-    BroadcastAnchoredEvent(BroadcastAnchoredEventMessage),
-}
-
-#[derive(Debug, Clone)]
-pub struct Player {
-    pub conn_id: Uuid,
-    pub uuid: Uuid,
-    pub name: String,
-    pub position: Position,
-    pub angle: Angle,
-    pub entity_id: i32,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct Position {
-    pub x: f64,
-    pub y: f64,
-    pub z: f64,
-}
-
-#[derive(Debug, Clone)]
-pub struct Angle {
-    pub pitch: f32,
-    pub yaw: f32,
-}
-
-#[derive(Debug, Clone)]
-pub struct BroadcastAnchoredEventMessage {
-    pub entity_id: i32,
-    pub packet: Packet,
-}
-
-#[derive(Debug)]
-pub struct NewPlayerMessage {
-    pub conn_id: Uuid,
-    pub player: Player,
-}
-
-#[derive(Debug)]
-pub struct ReportMessage {
-    pub conn_id: Uuid,
-}
-
-#[derive(Debug)]
-pub struct CrossBorderMessage {
-    pub local_conn_id: Uuid,
-    pub remote_conn_id: Uuid,
-}
-
-#[derive(Debug)]
-pub struct PlayerMoveAndLookMessage {
-    pub conn_id: Uuid,
-    pub new_position: Option<Position>,
-    pub new_angle: Option<Angle>,
-}
 
 pub fn start<M: Messenger + Clone>(receiver: Receiver<PlayerStateOperations>, messenger: M) {
     let mut players = HashMap::<Uuid, Player>::new();

--- a/src/services/packet_processor.rs
+++ b/src/services/packet_processor.rs
@@ -1,52 +1,16 @@
-use super::game_state::block::BlockState;
-use super::game_state::patchwork::PatchworkState;
-use super::game_state::player::PlayerState;
+use super::interfaces::block::BlockState;
 use super::interfaces::messenger::Messenger;
+use super::interfaces::packet_processor::PacketProcessorOperations;
+use super::interfaces::patchwork::PatchworkState;
+use super::interfaces::player::PlayerState;
+
 use super::packet::{read, translate};
 use super::packet_router;
 use super::translation::{TranslationInfo, TranslationUpdates};
 use std::collections::HashMap;
-use std::io::Cursor;
-use std::sync::mpsc::{Receiver, Sender};
+
+use std::sync::mpsc::Receiver;
 use uuid::Uuid;
-
-pub trait PacketProcessor {
-    fn inbound(&self, conn_id: Uuid, cursor: Cursor<Vec<u8>>);
-    fn set_translation_data(&self, conn_id: Uuid, updates: Vec<TranslationUpdates>);
-}
-
-impl PacketProcessor for Sender<PacketProcessorOperations> {
-    fn inbound(&self, conn_id: Uuid, cursor: Cursor<Vec<u8>>) {
-        self.send(PacketProcessorOperations::Inbound(InboundPacketMessage {
-            conn_id,
-            cursor,
-        }))
-        .unwrap()
-    }
-    fn set_translation_data(&self, conn_id: Uuid, updates: Vec<TranslationUpdates>) {
-        self.send(PacketProcessorOperations::SetTranslationData(
-            TranslationDataMessage { conn_id, updates },
-        ))
-        .unwrap();
-    }
-}
-
-pub enum PacketProcessorOperations {
-    Inbound(InboundPacketMessage),
-    SetTranslationData(TranslationDataMessage),
-}
-
-#[derive(Debug)]
-pub struct InboundPacketMessage {
-    pub conn_id: Uuid,
-    pub cursor: Cursor<Vec<u8>>,
-}
-
-#[derive(Debug)]
-pub struct TranslationDataMessage {
-    pub conn_id: Uuid,
-    pub updates: Vec<TranslationUpdates>,
-}
 
 pub fn start_inbound<
     M: Messenger + Clone,


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/108

### Why
Continuation of previous PR

### What
Applied the changes of the previous PR but for every service

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
