### PR TITLE
Handle disconnections without exploding

### DIFF
--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -1,4 +1,5 @@
 pub mod block;
+pub mod connection;
 pub mod messenger;
 pub mod packet_processor;
 pub mod patchwork;

--- a/src/interfaces/connection.rs
+++ b/src/interfaces/connection.rs
@@ -1,0 +1,17 @@
+use std::sync::mpsc::Sender;
+use uuid::Uuid;
+
+pub trait ConnectionService {
+    fn close(&self, conn_id: Uuid);
+}
+
+impl ConnectionService for Sender<ConnectionOperations> {
+    fn close(&self, conn_id: Uuid) {
+        self.send(ConnectionOperations::Close(conn_id)).unwrap();
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ConnectionOperations {
+    Close(Uuid),
+}

--- a/src/interfaces/messenger.rs
+++ b/src/interfaces/messenger.rs
@@ -10,6 +10,7 @@ pub trait Messenger {
     fn subscribe(&self, conn_id: Uuid, typ: SubscriberType);
     fn new_connection(&self, conn_id: Uuid, socket: TcpStream);
     fn update_translation(&self, conn_id: Uuid, map: Map);
+    fn close(&self, conn_id: Uuid);
 }
 
 impl Messenger for Sender<MessengerOperations> {
@@ -38,6 +39,11 @@ impl Messenger for Sender<MessengerOperations> {
         .unwrap();
     }
 
+    fn close(&self, conn_id: Uuid) {
+        self.send(MessengerOperations::Close(CloseMessage { conn_id }))
+            .unwrap();
+    }
+
     fn new_connection(&self, conn_id: Uuid, socket: TcpStream) {
         self.send(MessengerOperations::New(NewConnectionMessage {
             conn_id,
@@ -58,6 +64,7 @@ pub enum MessengerOperations {
     Send(SendPacketMessage),
     Broadcast(BroadcastPacketMessage),
     Subscribe(SubscribeMessage),
+    Close(CloseMessage),
     New(NewConnectionMessage),
     UpdateTranslation(UpdateTranslationMessage),
 }
@@ -78,6 +85,11 @@ pub struct UpdateTranslationMessage {
 pub struct SubscribeMessage {
     pub conn_id: Uuid,
     pub typ: SubscriberType,
+}
+
+#[derive(Debug)]
+pub struct CloseMessage {
+    pub conn_id: Uuid,
 }
 
 #[derive(Debug)]

--- a/src/interfaces/player.rs
+++ b/src/interfaces/player.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 
 pub trait PlayerState {
     fn new_player(&self, conn_id: Uuid, player: Player);
+    fn delete_player(&self, conn_id: Uuid);
     fn report(&self, conn_id: Uuid);
     fn move_and_look(
         &self,
@@ -20,6 +21,12 @@ impl PlayerState for Sender<PlayerStateOperations> {
         self.send(PlayerStateOperations::New(NewPlayerMessage {
             conn_id,
             player,
+        }))
+        .unwrap();
+    }
+    fn delete_player(&self, conn_id: Uuid) {
+        self.send(PlayerStateOperations::Delete(DeletePlayerMessage {
+            conn_id,
         }))
         .unwrap();
     }
@@ -59,6 +66,7 @@ impl PlayerState for Sender<PlayerStateOperations> {
 
 pub enum PlayerStateOperations {
     New(NewPlayerMessage),
+    Delete(DeletePlayerMessage),
     Report(ReportMessage),
     MoveAndLook(PlayerMoveAndLookMessage),
     CrossBorder(CrossBorderMessage),
@@ -98,6 +106,11 @@ pub struct BroadcastAnchoredEventMessage {
 pub struct NewPlayerMessage {
     pub conn_id: Uuid,
     pub player: Player,
+}
+
+#[derive(Debug)]
+pub struct DeletePlayerMessage {
+    pub conn_id: Uuid,
 }
 
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,11 @@ fn main() {
             dependencies: [messenger, player_state, block_state, patchwork_state]
         ),
         (
+            module: services::connection::start,
+            name: connection_service,
+            dependencies: [messenger, player_state, patchwork_state, inbound_packet_processor]
+        ),
+        (
             module: services::keep_alive::start,
             name: keep_alive,
             dependencies: [messenger]
@@ -83,5 +88,9 @@ fn main() {
         address: peer_address,
     });
 
-    server::listen(inbound_packet_processor.sender(), messenger.sender());
+    server::listen(
+        inbound_packet_processor.sender(),
+        connection_service.sender(),
+        messenger.sender(),
+    );
 }

--- a/src/models/map.rs
+++ b/src/models/map.rs
@@ -84,6 +84,7 @@ impl Map {
                 inbound_packet_processor_clone,
                 messenger_clone,
                 conn_id,
+                || {},
             );
         });
         let map = Map {

--- a/src/models/packet_macros.rs
+++ b/src/models/packet_macros.rs
@@ -68,7 +68,9 @@ macro_rules! packet_boilerplate {
             byte_vec.extend(size_vec);
 
             //Send the packet
-            stream.write_all(&byte_vec).unwrap();
+            stream.write_all(&byte_vec).unwrap_or_else(|e| {
+                warn!("Failed to write packet: {:?}", e);
+            });
         }
 
         pub fn translate(packet: Packet, translation_info: TranslationInfo) -> Packet {

--- a/src/services.rs
+++ b/src/services.rs
@@ -8,6 +8,7 @@ pub mod instance;
 #[macro_use]
 pub mod messenger;
 pub mod block;
+pub mod connection;
 pub mod keep_alive;
 pub mod packet_processor;
 pub mod patchwork;

--- a/src/services/connection.rs
+++ b/src/services/connection.rs
@@ -1,0 +1,29 @@
+use super::interfaces::connection::ConnectionOperations;
+use super::interfaces::messenger::Messenger;
+use super::interfaces::packet_processor::PacketProcessor;
+use super::interfaces::patchwork::PatchworkState;
+use super::interfaces::player::PlayerState;
+
+use std::sync::mpsc::Receiver;
+
+pub fn start<
+    M: Messenger + Clone,
+    P: PlayerState + Clone,
+    PA: PatchworkState + Clone,
+    PP: 'static + PacketProcessor + Clone + Send,
+>(
+    receiver: Receiver<ConnectionOperations>,
+    messenger: M,
+    player_state: P,
+    _patchwork_state: PA,
+    _packet_processor: PP,
+) {
+    while let Ok(msg) = receiver.recv() {
+        match msg {
+            ConnectionOperations::Close(conn_id) => {
+                messenger.close(conn_id);
+                player_state.delete_player(conn_id);
+            }
+        }
+    }
+}

--- a/src/services/messenger.rs
+++ b/src/services/messenger.rs
@@ -82,6 +82,13 @@ pub fn start(receiver: Receiver<MessengerOperations>) {
                     }
                 }
             }
+            MessengerOperations::Close(msg) => {
+                trace!("Closing connection {:?}", msg.conn_id);
+                connection_map.remove(&msg.conn_id);
+                translation_data.remove(&msg.conn_id);
+                local_only_broadcast_list.remove(&msg.conn_id);
+                all_broadcast_list.remove(&msg.conn_id);
+            }
             MessengerOperations::New(msg) => {
                 trace!(
                     "New Connection with conn_id {:?} on socket {:?}",

--- a/src/services/player.rs
+++ b/src/services/player.rs
@@ -54,6 +54,9 @@ fn handle_message<M: Messenger>(
             entity_conn_ids.insert(player.entity_id, msg.conn_id);
             players.insert(msg.conn_id, player);
         }
+        PlayerStateOperations::Delete(msg) => {
+            players.remove(&msg.conn_id);
+        }
         PlayerStateOperations::MoveAndLook(msg) => {
             trace!(
                 "Player Move/Look new_position: {:?} new_angle: {:?} for conn_id {:?}",


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/33

### Why
The servers would crash anytime someone disconnected, since we weren't properly removing connection ids that no longer existed

### What <!---Summary of whats in the PR-->

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
