### PR TITLE
Changed ordering in patchwork to fix bug

### DIFF
--- a/src/services/patchwork.rs
+++ b/src/services/patchwork.rs
@@ -45,6 +45,26 @@ pub fn start<
                         map_index: 0,
                         conn_id: None,
                     });
+                match &patchwork.maps[anchor.map_index].peer_connection {
+                    Some(_) => match msg.packet {
+                        Packet::Unknown => {}
+                        _ => {
+                            trace!(
+                                "Routing packet from conn_id {:?} through anchor",
+                                msg.conn_id
+                            );
+                            messenger.send_packet(anchor.conn_id.unwrap(), msg.packet.clone());
+                        }
+                    },
+                    None => {
+                        trace!("Routing packet from conn_id {:?} locally", msg.conn_id);
+                        gameplay_router::route_packet(
+                            msg.packet.clone(),
+                            msg.conn_id,
+                            player_state.clone(),
+                        );
+                    }
+                }
                 if let Some(position) = extract_map_position(msg.clone().packet) {
                     let new_map_index = patchwork_clone.position_map_index(position);
                     if new_map_index != anchor.map_index {
@@ -63,26 +83,6 @@ pub fn start<
                                 map_index: new_map_index,
                             },
                         }
-                    }
-                }
-                match &patchwork.maps[anchor.map_index].peer_connection {
-                    Some(_) => match msg.packet {
-                        Packet::Unknown => {}
-                        _ => {
-                            trace!(
-                                "Routing packet from conn_id {:?} through anchor",
-                                msg.conn_id
-                            );
-                            messenger.send_packet(anchor.conn_id.unwrap(), msg.packet);
-                        }
-                    },
-                    None => {
-                        trace!("Routing packet from conn_id {:?} locally", msg.conn_id);
-                        gameplay_router::route_packet(
-                            msg.packet,
-                            msg.conn_id,
-                            player_state.clone(),
-                        );
                     }
                 }
             }


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/70
### Why
When you started on server A, then walked someone from server B onto server A they were invisible

### What
Change ordering so that the packet that pushes the player over the border is still delivered. This allows us to send the correct position when performing the border crossing login procedure (otherwise we were sending that when one step behind, which caused the player to fail to load since they were out of the valid play area for server A)

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
