### PR TITLE
Send the delete entities packet when a player disconnects

### DIFF
--- a/src/models/packet_macros.rs
+++ b/src/models/packet_macros.rs
@@ -225,7 +225,7 @@ macro_rules! read_packet_field {
     };
     ($stream:ident, LengthPrefixedArray($type:ident)) => {{
         let length = $stream.read_var_int();
-        $stream.read_int_array(length as u32)
+        $stream.read_var_int_array(length as u32)
     }};
     ($stream:ident, Float) => {
         $stream.read_float()

--- a/src/packet_handlers/initiation_protocols/client_ping.rs
+++ b/src/packet_handlers/initiation_protocols/client_ping.rs
@@ -12,7 +12,7 @@ pub fn handle_client_ping_packet<M: Messenger>(
     conn_id: Uuid,
     messenger: M,
 ) -> TranslationUpdates {
-    match p.clone() {
+    match p {
         Packet::StatusRequest(_) => {
             let status_response = packet::StatusResponse {
                 json_response: String::from(FAKE_RESPONSE),

--- a/src/packet_handlers/initiation_protocols/login.rs
+++ b/src/packet_handlers/initiation_protocols/login.rs
@@ -20,7 +20,7 @@ pub fn handle_login_packet<
     block_state: B,
     patchwork_state: PA,
 ) -> TranslationUpdates {
-    match p.clone() {
+    match p {
         Packet::LoginStart(login_start) => {
             confirm_login(
                 conn_id,

--- a/src/packet_handlers/packet_router.rs
+++ b/src/packet_handlers/packet_router.rs
@@ -37,7 +37,7 @@ pub fn route_packet<
         ),
         Status::ClientPing => client_ping::handle_client_ping_packet(packet, conn_id, messenger),
         Status::Play => {
-            patchwork_state.route_player_packet(packet.clone(), conn_id);
+            patchwork_state.route_player_packet(packet, conn_id);
             TranslationUpdates::NoChange
         }
         Status::BorderCrossLogin => {

--- a/src/services/patchwork.rs
+++ b/src/services/patchwork.rs
@@ -184,7 +184,7 @@ impl Patchwork {
         messenger: M,
     ) {
         self.maps[map_index].peer_connection = Some(peer_connection);
-        self.maps[map_index].report(messenger.clone());
+        self.maps[map_index].report(messenger);
     }
 
     pub fn add_peer_map<


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/122

### Why
Players need to disappear when they disconnect, otherwise we get a bunch of corpses hanging around

### What
Send the necessary packet. Fix a bug where we would read the wrong kind of int array.

Also there were some clippy things I missed in the last PR that I've fixed here

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
