### PR TITLE
Add border cross handshake packet

### DIFF
--- a/src/models/packet.rs
+++ b/src/models/packet.rs
@@ -60,6 +60,16 @@ packet_boilerplate!(
         ]
     ),
     (6, ReportState, 0x1, []),
+    (_, BorderCrossLogin, 0xA0, [
+            (x, Double, XEntity),
+            (feet_y, Double),
+            (z, Double),
+            (yaw, Float),
+            (pitch, Float),
+            (on_ground, Boolean),
+            (username, String),
+            (entity_id, Int, EntityId)
+    ]),
     (99, Pong, 1, [(payload, Long)]),
     (99, StatusResponse, 0, [(json_response, String)]),
     (99, LoginSuccess, 2, [(uuid, String), (username, String)]),

--- a/src/packet_handlers/initiation_protocols/border_cross_login.rs
+++ b/src/packet_handlers/initiation_protocols/border_cross_login.rs
@@ -9,15 +9,13 @@ pub fn border_cross_login<P: PlayerState>(
     player_state: P,
 ) -> TranslationUpdates {
     match p {
-        Packet::PlayerPositionAndLook(packet) => {
+        Packet::BorderCrossLogin(packet) => {
             let player = Player {
                 conn_id,
                 uuid: Uuid::new_v4(),
-                name: String::from("ghost"),
-                // hard coded to only work for the first player to login
-                // need to augment this packet to include the entity id on the host peer for this
-                // to work
-                entity_id: 950,
+                name: packet.username,
+                //Hardcoded to assume that 950-1000 is the range used for this peer's anchors
+                entity_id: 950 + packet.entity_id,
                 position: Position {
                     x: packet.x,
                     y: packet.feet_y,

--- a/src/services/player.rs
+++ b/src/services/player.rs
@@ -2,8 +2,8 @@ use super::interfaces::messenger::Messenger;
 use super::interfaces::player::{Angle, Player, PlayerStateOperations, Position};
 use super::minecraft_types::float_to_angle;
 use super::packet::{
-    ClientboundPlayerPositionAndLook, DestroyEntities, EntityHeadLook, EntityLookAndMove, JoinGame,
-    Packet, PlayerInfo, PlayerPositionAndLook, SpawnPlayer,
+    BorderCrossLogin, ClientboundPlayerPositionAndLook, DestroyEntities, EntityHeadLook,
+    EntityLookAndMove, JoinGame, Packet, PlayerInfo, SpawnPlayer,
 };
 use std::collections::HashMap;
 
@@ -129,21 +129,23 @@ fn handle_message<M: Messenger>(
                 .expect("Could not cross border: player not found");
             messenger.send_packet(
                 msg.remote_conn_id,
-                Packet::PlayerPositionAndLook(player.player_position_and_look()),
+                Packet::BorderCrossLogin(player.border_cross_login()),
             );
         }
     }
 }
 
 impl Player {
-    pub fn player_position_and_look(&self) -> PlayerPositionAndLook {
-        PlayerPositionAndLook {
+    pub fn border_cross_login(&self) -> BorderCrossLogin {
+        BorderCrossLogin {
             x: self.position.x,
             feet_y: self.position.y,
             z: self.position.z,
             yaw: self.angle.yaw,
             pitch: self.angle.pitch,
             on_ground: false,
+            username: self.name.clone(),
+            entity_id: self.entity_id,
         }
     }
 


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/123

### Why 
We weren't sending all the info we needed during the border crossing protocol, so it would only use a single entity id and a single username for everybody

### What
Add a handshake packet that communicates entity id and username as well as position

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
