### PR TITLE
Reintroduce players who walk over the border

### DIFF
--- a/src/interfaces/player.rs
+++ b/src/interfaces/player.rs
@@ -14,6 +14,7 @@ pub trait PlayerState {
     );
     fn cross_border(&self, local_conn_id: Uuid, remote_conn_id: Uuid);
     fn broadcast_anchored_event(&self, entity_id: i32, packet: Packet);
+    fn reintroduce(&self, conn_id: Uuid);
 }
 
 impl PlayerState for Sender<PlayerStateOperations> {
@@ -56,6 +57,12 @@ impl PlayerState for Sender<PlayerStateOperations> {
         }))
         .unwrap();
     }
+    fn reintroduce(&self, conn_id: Uuid) {
+        self.send(PlayerStateOperations::Reintroduce(ReintroduceMessage {
+            conn_id,
+        }))
+        .unwrap();
+    }
     fn broadcast_anchored_event(&self, entity_id: i32, packet: Packet) {
         self.send(PlayerStateOperations::BroadcastAnchoredEvent(
             BroadcastAnchoredEventMessage { entity_id, packet },
@@ -70,6 +77,7 @@ pub enum PlayerStateOperations {
     Report(ReportMessage),
     MoveAndLook(PlayerMoveAndLookMessage),
     CrossBorder(CrossBorderMessage),
+    Reintroduce(ReintroduceMessage),
     BroadcastAnchoredEvent(BroadcastAnchoredEventMessage),
 }
 
@@ -122,6 +130,11 @@ pub struct ReportMessage {
 pub struct CrossBorderMessage {
     pub local_conn_id: Uuid,
     pub remote_conn_id: Uuid,
+}
+
+#[derive(Debug)]
+pub struct ReintroduceMessage {
+    pub conn_id: Uuid,
 }
 
 #[derive(Debug)]

--- a/src/packet_handlers/peer_subscription.rs
+++ b/src/packet_handlers/peer_subscription.rs
@@ -16,6 +16,15 @@ pub fn handle_peer_packet<M: Messenger, P: PlayerState>(
                 messenger.broadcast_packet(Packet::SpawnPlayer(packet), None, false);
             }
         }
+        Packet::DestroyEntities(packet) => {
+            assert!(
+                packet.entity_ids.len() == 1,
+                "Cannot handle entity destroy packets from peers with multiple ids"
+            );
+            if packet.entity_ids[0] >= 1000 {
+                messenger.broadcast_packet(Packet::DestroyEntities(packet), None, false);
+            }
+        }
         //We really don't want to have to do this for every type of packet that has an entity id
         //There's probably a better solution here, a macro might do it since the code should be
         //identical but then we still need to list all the packets we can get from the peer that

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,7 +5,7 @@ use super::interfaces::packet_processor::PacketProcessor;
 use super::models::minecraft_protocol::MinecraftProtocolReader;
 
 use std::env;
-use std::io::ErrorKind::UnexpectedEof;
+use std::io::ErrorKind::{ConnectionReset, UnexpectedEof};
 use std::io::{Cursor, Error, Read};
 use std::net::{TcpListener, TcpStream};
 use std::thread;
@@ -71,6 +71,7 @@ pub fn handle_connection<M: Messenger, PP: PacketProcessor, F: Fn()>(
             Err(e) => {
                 match e.kind() {
                     UnexpectedEof => on_closure(),
+                    ConnectionReset => on_closure(),
                     _ => {
                         panic!("conn closed due to {:?}", e);
                     }

--- a/src/services/messenger.rs
+++ b/src/services/messenger.rs
@@ -67,6 +67,15 @@ pub fn start(receiver: Receiver<MessengerOperations>, _sender: Sender<MessengerO
                     });
                 }
             }
+            MessengerOperations::BroadcastRemote(msg) => {
+                (&local_only_broadcast_list).iter().for_each(|conn_id| {
+                    if let Some(socket) = connection_map.get(&conn_id) {
+                        let mut socket_clone = socket.try_clone().unwrap();
+                        let packet_clone = msg.packet.clone();
+                        write(&mut socket_clone, packet_clone);
+                    }
+                });
+            }
             MessengerOperations::Subscribe(msg) => {
                 trace!(
                     "Subscribing conn_id {:?} with type {:?}",


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/120

### Why
We weren't properly handling the case of the player walking back onto their home server after crossing onto a peer's server

### What

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
