### PR TITLE
Block bug

### DIFF
--- a/src/models/minecraft_protocol.rs
+++ b/src/models/minecraft_protocol.rs
@@ -238,7 +238,7 @@ fn write_chunk_section<S: Write>(stream: &mut S, v: ChunkSection) {
     stream.write_var_int(v.data_array_length);
     let mut long: i64 = 0;
     for i in 0..4096 {
-        let block_to_place = v.block_ids[i as usize] as i64;
+        let block_to_place = i64::from(v.block_ids[i as usize]);
         let offset = (PALETTE_SIZE * i) % 64;
         long += block_to_place << offset;
         if ((i * PALETTE_SIZE) % 64) >= 64 - PALETTE_SIZE {

--- a/src/models/minecraft_protocol.rs
+++ b/src/models/minecraft_protocol.rs
@@ -281,8 +281,8 @@ fn read_chunk_section<S: Read>(stream: &mut S) -> ChunkSection {
         if bits_to_read < 14 {
             let remainder_to_read = 14 - bits_to_read;
             let remainder = long << (64 - remainder_to_read) >> (64 - remainder_to_read);
-            block_id += remainder >> remainder_to_read;
-        };
+            block_id += remainder << bits_to_read;
+        }
         block_ids.push(block_id as i32);
         index += 14;
     }


### PR DESCRIPTION
<!---The purpose of this template is to make our PRs more consistent and have them break shit less often-->
Issue: <!---Link the GH issue this relates to here. If you don't have an issue delete this but use an issue next time. They're useful for tracking work-->
[https://github.com/DuncanUszkay1/Patchwork/issues/101](url)

### Why <!---Short summary of issue that this pr is solving. You can just put 'see issue' if the information is in the issue-->
Reading blocks was returning the wrong blocks

### What <!---Summary of whats in the PR-->
I corrected the bug that happened when reading blocks in read_chunk_section. The bit shifts were slightly wrong when there were less than 14 bits to read.

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template