### PR TITLE
Make macro to compress interface boilerplate

### DIFF
--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+mod interface_macro;
 pub mod block;
 pub mod connection;
 pub mod messenger;

--- a/src/interfaces/block.rs
+++ b/src/interfaces/block.rs
@@ -1,22 +1,4 @@
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
 
-pub trait BlockState {
-    fn report(&self, conn_id: Uuid);
-}
-
-impl BlockState for Sender<BlockStateOperations> {
-    fn report(&self, conn_id: Uuid) {
-        self.send(BlockStateOperations::Report(ReportMessage { conn_id }))
-            .unwrap();
-    }
-}
-
-pub enum BlockStateOperations {
-    Report(ReportMessage),
-}
-
-#[derive(Debug)]
-pub struct ReportMessage {
-    pub conn_id: Uuid,
-}
+define_interface!(BlockState, (Report, report, [conn_id: Uuid]));

--- a/src/interfaces/connection.rs
+++ b/src/interfaces/connection.rs
@@ -1,17 +1,4 @@
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
 
-pub trait ConnectionService {
-    fn close(&self, conn_id: Uuid);
-}
-
-impl ConnectionService for Sender<ConnectionOperations> {
-    fn close(&self, conn_id: Uuid) {
-        self.send(ConnectionOperations::Close(conn_id)).unwrap();
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum ConnectionOperations {
-    Close(Uuid),
-}
+define_interface!(ConnectionService, (Close, close, [conn_id: Uuid]));

--- a/src/interfaces/interface_macro.rs
+++ b/src/interfaces/interface_macro.rs
@@ -1,0 +1,29 @@
+macro_rules! define_interface {
+    ($name:ident,
+            $( ( $op:ident, $op_method:ident, [ $( $field_name:ident: $field_type:ty ),* ] ) ),*
+    ) => {
+        pub trait $name {
+            $( fn $op_method(&self, $( $field_name: $field_type ),*); )*
+        }
+
+        impl $name for Sender<Operations> {
+            $(
+                fn $op_method(&self, $( $field_name: $field_type ),*) {
+                    self.send(Operations::$op($op { $( $field_name ),* }))
+                        .unwrap();
+                }
+            )*
+        }
+
+        pub enum Operations {
+            $( $op($op), )*
+        }
+
+        $(
+            #[derive(Debug)]
+            pub struct $op {
+                $( pub $field_name: $field_type, )*
+            }
+        )*
+    }
+}

--- a/src/interfaces/packet_processor.rs
+++ b/src/interfaces/packet_processor.rs
@@ -4,40 +4,12 @@ use std::io::Cursor;
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
 
-pub trait PacketProcessor {
-    fn inbound(&self, conn_id: Uuid, cursor: Cursor<Vec<u8>>);
-    fn set_translation_data(&self, conn_id: Uuid, updates: Vec<TranslationUpdates>);
-}
-
-impl PacketProcessor for Sender<PacketProcessorOperations> {
-    fn inbound(&self, conn_id: Uuid, cursor: Cursor<Vec<u8>>) {
-        self.send(PacketProcessorOperations::Inbound(InboundPacketMessage {
-            conn_id,
-            cursor,
-        }))
-        .unwrap()
-    }
-    fn set_translation_data(&self, conn_id: Uuid, updates: Vec<TranslationUpdates>) {
-        self.send(PacketProcessorOperations::SetTranslationData(
-            TranslationDataMessage { conn_id, updates },
-        ))
-        .unwrap();
-    }
-}
-
-pub enum PacketProcessorOperations {
-    Inbound(InboundPacketMessage),
-    SetTranslationData(TranslationDataMessage),
-}
-
-#[derive(Debug)]
-pub struct InboundPacketMessage {
-    pub conn_id: Uuid,
-    pub cursor: Cursor<Vec<u8>>,
-}
-
-#[derive(Debug)]
-pub struct TranslationDataMessage {
-    pub conn_id: Uuid,
-    pub updates: Vec<TranslationUpdates>,
-}
+define_interface!(
+    PacketProcessor,
+    (Inbound, inbound, [conn_id: Uuid, cursor: Cursor<Vec<u8>>]),
+    (
+        SetTranslationData,
+        set_translation_data,
+        [conn_id: Uuid, updates: Vec<TranslationUpdates>]
+    )
+);

--- a/src/interfaces/patchwork.rs
+++ b/src/interfaces/patchwork.rs
@@ -3,60 +3,18 @@ use super::packet::Packet;
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
 
-pub trait PatchworkState {
-    fn new_map(&self, peer: Peer);
-    fn route_player_packet(&self, packet: Packet, conn_id: Uuid);
-    fn connect_map(&self, map_index: usize, conn_id: PeerConnection);
-    fn report(&self);
-}
-
-impl PatchworkState for Sender<PatchworkStateOperations> {
-    fn new_map(&self, peer: Peer) {
-        self.send(PatchworkStateOperations::New(NewMapMessage { peer }))
-            .unwrap();
-    }
-
-    fn connect_map(&self, map_index: usize, peer_connection: PeerConnection) {
-        self.send(PatchworkStateOperations::ConnectMap(ConnectMapMessage {
-            map_index,
-            peer_connection,
-        }))
-        .unwrap();
-    }
-
-    fn route_player_packet(&self, packet: Packet, conn_id: Uuid) {
-        self.send(PatchworkStateOperations::RoutePlayerPacket(RouteMessage {
-            packet,
-            conn_id,
-        }))
-        .unwrap();
-    }
-
-    fn report(&self) {
-        self.send(PatchworkStateOperations::Report).unwrap();
-    }
-}
-
-pub enum PatchworkStateOperations {
-    New(NewMapMessage),
-    RoutePlayerPacket(RouteMessage),
-    ConnectMap(ConnectMapMessage),
-    Report,
-}
-
-#[derive(Debug)]
-pub struct NewMapMessage {
-    pub peer: Peer,
-}
-
-#[derive(Debug)]
-pub struct ConnectMapMessage {
-    pub map_index: usize,
-    pub peer_connection: PeerConnection,
-}
-
-#[derive(Debug, Clone)]
-pub struct RouteMessage {
-    pub packet: Packet,
-    pub conn_id: Uuid,
-}
+define_interface!(
+    PatchworkState,
+    (Report, report, []),
+    (New, new_map, [peer: Peer]),
+    (
+        RoutePlayerPacket,
+        route_player_packet,
+        [packet: Packet, conn_id: Uuid]
+    ),
+    (
+        ConnectMap,
+        connect_map,
+        [map_index: usize, peer_connection: PeerConnection]
+    )
+);

--- a/src/interfaces/player.rs
+++ b/src/interfaces/player.rs
@@ -2,84 +2,32 @@ use super::packet::Packet;
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
 
-pub trait PlayerState {
-    fn new_player(&self, conn_id: Uuid, player: Player);
-    fn delete_player(&self, conn_id: Uuid);
-    fn report(&self, conn_id: Uuid);
-    fn move_and_look(
-        &self,
-        conn_id: Uuid,
-        new_position: Option<Position>,
-        new_angle: Option<Angle>,
-    );
-    fn cross_border(&self, local_conn_id: Uuid, remote_conn_id: Uuid);
-    fn broadcast_anchored_event(&self, entity_id: i32, packet: Packet);
-    fn reintroduce(&self, conn_id: Uuid);
-}
-
-impl PlayerState for Sender<PlayerStateOperations> {
-    fn new_player(&self, conn_id: Uuid, player: Player) {
-        self.send(PlayerStateOperations::New(NewPlayerMessage {
-            conn_id,
-            player,
-        }))
-        .unwrap();
-    }
-    fn delete_player(&self, conn_id: Uuid) {
-        self.send(PlayerStateOperations::Delete(DeletePlayerMessage {
-            conn_id,
-        }))
-        .unwrap();
-    }
-    fn report(&self, conn_id: Uuid) {
-        self.send(PlayerStateOperations::Report(ReportMessage { conn_id }))
-            .unwrap();
-    }
-    fn move_and_look(
-        &self,
-        conn_id: Uuid,
-        new_position: Option<Position>,
-        new_angle: Option<Angle>,
-    ) {
-        self.send(PlayerStateOperations::MoveAndLook(
-            PlayerMoveAndLookMessage {
-                conn_id,
-                new_position,
-                new_angle,
-            },
-        ))
-        .unwrap();
-    }
-    fn cross_border(&self, local_conn_id: Uuid, remote_conn_id: Uuid) {
-        self.send(PlayerStateOperations::CrossBorder(CrossBorderMessage {
-            local_conn_id,
-            remote_conn_id,
-        }))
-        .unwrap();
-    }
-    fn reintroduce(&self, conn_id: Uuid) {
-        self.send(PlayerStateOperations::Reintroduce(ReintroduceMessage {
-            conn_id,
-        }))
-        .unwrap();
-    }
-    fn broadcast_anchored_event(&self, entity_id: i32, packet: Packet) {
-        self.send(PlayerStateOperations::BroadcastAnchoredEvent(
-            BroadcastAnchoredEventMessage { entity_id, packet },
-        ))
-        .unwrap();
-    }
-}
-
-pub enum PlayerStateOperations {
-    New(NewPlayerMessage),
-    Delete(DeletePlayerMessage),
-    Report(ReportMessage),
-    MoveAndLook(PlayerMoveAndLookMessage),
-    CrossBorder(CrossBorderMessage),
-    Reintroduce(ReintroduceMessage),
-    BroadcastAnchoredEvent(BroadcastAnchoredEventMessage),
-}
+define_interface!(
+    PlayerState,
+    (Report, report, [conn_id: Uuid]),
+    (New, new_player, [conn_id: Uuid, player: Player]),
+    (Delete, delete_player, [conn_id: Uuid]),
+    (
+        MoveAndLook,
+        move_and_look,
+        [
+            conn_id: Uuid,
+            new_position: Option<Position>,
+            new_angle: Option<Angle>
+        ]
+    ),
+    (
+        CrossBorder,
+        cross_border,
+        [local_conn_id: Uuid, remote_conn_id: Uuid]
+    ),
+    (
+        BroadcastAnchoredEvent,
+        broadcast_anchored_event,
+        [entity_id: i32, packet: Packet]
+    ),
+    (Reintroduce, reintroduce, [conn_id: Uuid])
+);
 
 #[derive(Debug, Clone)]
 pub struct Player {
@@ -102,44 +50,4 @@ pub struct Position {
 pub struct Angle {
     pub pitch: f32,
     pub yaw: f32,
-}
-
-#[derive(Debug, Clone)]
-pub struct BroadcastAnchoredEventMessage {
-    pub entity_id: i32,
-    pub packet: Packet,
-}
-
-#[derive(Debug)]
-pub struct NewPlayerMessage {
-    pub conn_id: Uuid,
-    pub player: Player,
-}
-
-#[derive(Debug)]
-pub struct DeletePlayerMessage {
-    pub conn_id: Uuid,
-}
-
-#[derive(Debug)]
-pub struct ReportMessage {
-    pub conn_id: Uuid,
-}
-
-#[derive(Debug)]
-pub struct CrossBorderMessage {
-    pub local_conn_id: Uuid,
-    pub remote_conn_id: Uuid,
-}
-
-#[derive(Debug)]
-pub struct ReintroduceMessage {
-    pub conn_id: Uuid,
-}
-
-#[derive(Debug)]
-pub struct PlayerMoveAndLookMessage {
-    pub conn_id: Uuid,
-    pub new_position: Option<Position>,
-    pub new_angle: Option<Angle>,
 }

--- a/src/services/block.rs
+++ b/src/services/block.rs
@@ -1,4 +1,4 @@
-use super::interfaces::block::BlockStateOperations;
+use super::interfaces::block::Operations;
 use super::interfaces::messenger::Messenger;
 use super::minecraft_types::ChunkSection;
 use super::packet::{ChunkData, Packet};
@@ -25,13 +25,13 @@ fn fill_dummy_block_ids(ids: &mut Vec<i32>) {
 }
 
 pub fn start<M: Messenger>(
-    receiver: Receiver<BlockStateOperations>,
-    _sender: Sender<BlockStateOperations>,
+    receiver: Receiver<Operations>,
+    _sender: Sender<Operations>,
     messenger: M,
 ) {
     while let Ok(msg) = receiver.recv() {
         match msg {
-            BlockStateOperations::Report(msg) => {
+            Operations::Report(msg) => {
                 trace!("Reporting block state to {:?}", msg.conn_id);
                 //Just send a hardcoded simple chunk pillar
                 let mut block_ids = Vec::new();

--- a/src/services/connection.rs
+++ b/src/services/connection.rs
@@ -1,4 +1,4 @@
-use super::interfaces::connection::ConnectionOperations;
+use super::interfaces::connection::Operations;
 use super::interfaces::messenger::Messenger;
 use super::interfaces::packet_processor::PacketProcessor;
 use super::interfaces::patchwork::PatchworkState;
@@ -12,8 +12,8 @@ pub fn start<
     PA: PatchworkState + Clone,
     PP: 'static + PacketProcessor + Clone + Send,
 >(
-    receiver: Receiver<ConnectionOperations>,
-    _sender: Sender<ConnectionOperations>,
+    receiver: Receiver<Operations>,
+    _sender: Sender<Operations>,
     messenger: M,
     player_state: P,
     _patchwork_state: PA,
@@ -21,9 +21,9 @@ pub fn start<
 ) {
     while let Ok(msg) = receiver.recv() {
         match msg {
-            ConnectionOperations::Close(conn_id) => {
-                messenger.close(conn_id);
-                player_state.delete_player(conn_id);
+            Operations::Close(msg) => {
+                messenger.close(msg.conn_id);
+                player_state.delete_player(msg.conn_id);
             }
         }
     }

--- a/src/services/packet_processor.rs
+++ b/src/services/packet_processor.rs
@@ -1,6 +1,6 @@
 use super::interfaces::block::BlockState;
 use super::interfaces::messenger::Messenger;
-use super::interfaces::packet_processor::PacketProcessorOperations;
+use super::interfaces::packet_processor::Operations;
 use super::interfaces::patchwork::PatchworkState;
 use super::interfaces::player::PlayerState;
 
@@ -18,8 +18,8 @@ pub fn start_inbound<
     PA: PatchworkState + Clone,
     B: BlockState + Clone,
 >(
-    receiver: Receiver<PacketProcessorOperations>,
-    _sender: Sender<PacketProcessorOperations>,
+    receiver: Receiver<Operations>,
+    _sender: Sender<Operations>,
     messenger: M,
     player_state: P,
     block_state: B,
@@ -29,7 +29,7 @@ pub fn start_inbound<
 
     while let Ok(msg) = receiver.recv() {
         match msg {
-            PacketProcessorOperations::Inbound(msg) => {
+            Operations::Inbound(msg) => {
                 trace!("Received packet from conn_id {:?}", msg.conn_id);
                 let translation_data = translation_data
                     .entry(msg.conn_id)
@@ -58,7 +58,7 @@ pub fn start_inbound<
                 }
                 translation_data.update(&translation_update);
             }
-            PacketProcessorOperations::SetTranslationData(msg) => {
+            Operations::SetTranslationData(msg) => {
                 trace!(
                     "Applying translation updates {:?} to {:?}",
                     msg.updates,


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/132

### Why
Interfaces had a ton of associated boilerplate, making it a hassle to edit and read.

### What
Wrote a macro to compress that code.

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
