### PR TITLE
Fix bug that caused new players to see the wrong position for anchored

### DIFF
--- a/src/interfaces/player.rs
+++ b/src/interfaces/player.rs
@@ -17,6 +17,15 @@ define_interface!(
         ]
     ),
     (
+        AnchoredMoveAndLook,
+        anchored_move_and_look,
+        [
+            conn_id: Uuid,
+            new_position: Option<Position>,
+            new_angle: Option<Angle>
+        ]
+    ),
+    (
         CrossBorder,
         cross_border,
         [local_conn_id: Uuid, remote_conn_id: Uuid]

--- a/src/services/patchwork.rs
+++ b/src/services/patchwork.rs
@@ -1,7 +1,7 @@
 use super::interfaces::messenger::Messenger;
 use super::interfaces::packet_processor::PacketProcessor;
 use super::interfaces::patchwork::Operations;
-use super::interfaces::player::PlayerState;
+use super::interfaces::player::{PlayerState, Position as PlayerPosition};
 use super::map::{Map, Peer, PeerConnection, Position};
 use super::packet;
 use super::packet::Packet;
@@ -57,6 +57,11 @@ pub fn start<
                             trace!(
                                 "Routing packet from conn_id {:?} through anchor",
                                 msg.conn_id
+                            );
+                            player_state.anchored_move_and_look(
+                                msg.conn_id,
+                                extract_player_position((&msg.packet).clone()),
+                                None,
                             );
                             messenger.send_packet(anchor.conn_id.unwrap(), msg.packet.clone());
                         }
@@ -119,6 +124,22 @@ fn extract_map_position(packet: Packet) -> Option<Position> {
         Packet::PlayerPositionAndLook(packet) => Some(Position {
             x: (packet.x / 16.0) as i32,
             z: (packet.z / 16.0) as i32,
+        }),
+        _ => None,
+    }
+}
+
+fn extract_player_position(packet: Packet) -> Option<PlayerPosition> {
+    match packet {
+        Packet::PlayerPosition(packet) => Some(PlayerPosition {
+            x: packet.x,
+            y: packet.feet_y,
+            z: packet.z,
+        }),
+        Packet::PlayerPositionAndLook(packet) => Some(PlayerPosition {
+            x: packet.x,
+            y: packet.feet_y,
+            z: packet.z,
         }),
         _ => None,
     }

--- a/src/services/player.rs
+++ b/src/services/player.rs
@@ -100,6 +100,17 @@ fn handle_message<M: Messenger>(
                 );
             });
         }
+        Operations::AnchoredMoveAndLook(msg) => {
+            trace!(
+                "Anchored Player Move/Look new_position: {:?} new_angle: {:?} for conn_id {:?}",
+                msg.new_position,
+                msg.new_angle,
+                msg.conn_id
+            );
+            players.entry(msg.conn_id).and_modify(|player| {
+                player.move_and_look(msg.new_position, msg.new_angle);
+            });
+        }
         Operations::Report(msg) => players.iter().for_each(|(conn_id, player)| {
             trace!("Reporting Player State to conn_id {:?}", conn_id);
             if *conn_id != msg.conn_id {


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/137

### Why
When a player spawned onto a server, all the players who were anchored on other servers would appear to be on the border of their original server. That's because we stopped recording the players position when they crossed the border- we would check every movement packet what server they were on, but then would discard the position since the peer was already sending packets for that player. That means that when a new player spawned, the last position we remember the anchored player to be at was the border.

### What
 I've added a new player method that allows you to change the position and angle without sending any update packets. This lets us update the players position so that when new players logon we know where to spawn the anchored players initially

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
