### PR TITLE
Skeleton for the unit tests.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -96,3 +96,169 @@ fn main() {
         messenger.sender(),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::interfaces::connection::ConnectionService;
+    use crate::interfaces::messenger::Messenger;
+    use crate::interfaces::packet_processor::PacketProcessor;
+    use crate::models::minecraft_protocol::MinecraftProtocolReader;
+    use crate::*;
+
+    fn start_trace() {
+        let logger_config = ConfigBuilder::new()
+            .set_max_level(LevelFilter::Off)
+            .set_thread_level(LevelFilter::Off)
+            .set_target_level(LevelFilter::Off)
+            .build();
+        SimpleLogger::init(LevelFilter::Trace, logger_config).unwrap();
+    }
+
+    fn handle_connection<M: Messenger, PP: PacketProcessor, F: Fn()>(
+        mut stream: std::net::TcpStream,
+        inbound_packet_processor: PP,
+        messenger: M,
+        id: uuid::Uuid,
+        on_closure: F,
+        sx: std::sync::mpsc::Sender<i32>,
+    ) {
+        let stream_clone = stream.try_clone().expect("Failed to clone stream");
+        messenger.new_connection(id, stream_clone);
+        loop {
+            match stream.try_read_var_int() {
+                Ok(length) => {
+                    sx.send(length).expect("Failed to send data to channel");
+                }
+                Err(e) => {
+                    match e.kind() {
+                        std::io::ErrorKind::UnexpectedEof => on_closure(),
+                        std::io::ErrorKind::ConnectionReset => on_closure(),
+                        _ => {
+                            panic!("Connection closed due to {:?}", e);
+                        }
+                    };
+                    break;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test() {
+        start_trace();
+
+        define_services!(
+            (
+                module: services::player::start,
+                name: player_state,
+                dependencies: [messenger]
+            ),
+            (
+                module: services::block::start,
+                name: block_state,
+                dependencies: [messenger]
+            ),
+            (
+                module: services::patchwork::start,
+                name: patchwork_state,
+                dependencies: [messenger, inbound_packet_processor, player_state]
+            ),
+            (
+                module: services::messenger::start,
+                name: messenger,
+                dependencies: []
+            ),
+            (
+                module: services::packet_processor::start_inbound,
+                name: inbound_packet_processor,
+                dependencies: [messenger, player_state, block_state, patchwork_state]
+            ),
+            (
+                module: services::connection::start,
+                name: connection_service,
+                dependencies: [messenger, player_state, patchwork_state, inbound_packet_processor]
+            ),
+            (
+                module: services::keep_alive::start,
+                name: keep_alive,
+                dependencies: [messenger]
+            )
+        );
+        trace!("Services Started");
+
+        // Temporary, maybe set them through CLI
+        std::env::set_var("PORT", "8600");
+        std::env::set_var("PEER_PORT", "8601");
+
+        let address = String::from("127.0.0.1");
+        let port = std::env::var("PORT").unwrap().parse::<u16>().unwrap();
+        let peer_port = std::env::var("PEER_PORT").unwrap().parse::<u16>().unwrap();
+
+        patchwork_state.sender().new_map(models::map::Peer {
+            port: peer_port.clone(),
+            address: address.clone(),
+        });
+
+        // Since servers handle connection in their own thread, create a channel
+        // to retrieve information
+        let (tx, rx) = std::sync::mpsc::channel();
+        let tx_clone = tx.clone();
+
+        // Start a dummy peer server (although manually, it is the same code as server::listen(),
+        // what's been added is the interaction with the channel)
+        let connection_string = format!("{}:{}", address, peer_port);
+        let connection_string_clone = connection_string.clone();
+        let ipp = inbound_packet_processor.sender().clone();
+        let ipp2 = ipp.clone();
+        let msgr = messenger.sender().clone();
+        let msgr2 = msgr.clone();
+        let ccs = connection_service.sender().clone();
+        let ccs2 = ccs.clone();
+
+        std::thread::spawn(move || {
+            let listener = std::net::TcpListener::bind(connection_string_clone.clone())
+                .expect("Failed to bind socket");
+            trace!("Listening on {:?}", connection_string_clone);
+
+            for stream in listener.incoming() {
+                let stream = stream.expect("Failed to connect to client");
+                let ipp_clone = ipp.clone();
+                let msgr_clone = msgr.clone();
+                let ccs_clone = ccs.clone();
+                let id = uuid::Uuid::new_v4();
+                let sx = tx_clone.clone();
+                thread::spawn(move || {
+                    handle_connection(
+                        stream,
+                        ipp_clone,
+                        msgr_clone,
+                        id,
+                        || ccs_clone.close(id),
+                        sx,
+                    );
+                });
+            }
+        });
+
+        // Start a proper server on its own thread
+        std::thread::spawn(move || {
+            server::listen(ipp2, ccs2, msgr2);
+        });
+
+        // Ensure some delay to let the server launch
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        match std::net::TcpStream::connect(connection_string.clone()) {
+            Ok(stream) => {
+                trace!("Connection successful to {}", connection_string);
+                let length: i32 = rx.recv().expect("Failed to receive data from channel");
+                trace!("Received packet length {}", length);
+                stream
+                    .shutdown(std::net::Shutdown::Both)
+                    .expect("Failed to shutdown connection"); // Everything went OK, close server and client
+            }
+            Err(_why) => {
+                panic!("Failed to connect to {}", connection_string);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## First integration test - Tests the length of the first message received.

<!---The purpose of this template is to make our PRs more consistent and have them break shit less often-->
Issue: [Integration tests (Issue 127)](https://github.com/DuncanUszkay1/Patchwork/issues/127)

### Why <!---Short summary of issue that this pr is solving. You can just put 'see issue' if the information is in the issue-->
We are at a point of the development where we need to automate tests. The main advantage of tests over the manual integration testing would be that we can check correctness on our codes quicker (no need to launch a Minecraft client for the moment, we can manually send packages)

### What <!---Summary of whats in the PR-->
The purpose of this PR is to show how tests may be organized. To allow control over packets, we need to manually set up a "dummy" server. By doing so, it allows us to control when and where to check for correctness in the packets using channels.
This is checked by simply running `cargo test` in the terminal of your choice

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
