### PR TITLE
Add chat commands to add maps

### DIFF
--- a/src/models/packet.rs
+++ b/src/models/packet.rs
@@ -37,6 +37,12 @@ packet_boilerplate!(
         ]
     ),
     (
+        3,
+        ChatMessage,
+        0x02,
+        [(message, String)]
+    ),
+    (
         _, //Temporary for border crossing, once it has its own packet change this back to 3
         PlayerPositionAndLook,
         0x11,

--- a/src/packet_handlers.rs
+++ b/src/packet_handlers.rs
@@ -4,12 +4,14 @@
 // Example: the gameplay router provides the route_packet method which handles packets from clients
 // in the play state
 
+pub mod chat_message_router;
 pub mod gameplay_router;
 pub mod initiation_protocols;
 pub mod packet_router;
 pub mod peer_subscription;
 
 use super::constants;
+use super::models::map::Peer;
 use super::models::minecraft_types;
 use super::models::packet;
 use super::models::translation;

--- a/src/packet_handlers/chat_message_router.rs
+++ b/src/packet_handlers/chat_message_router.rs
@@ -1,0 +1,42 @@
+use super::interfaces::patchwork::PatchworkState;
+use super::packet::Packet;
+use super::Peer;
+use uuid::Uuid;
+
+pub fn route_packet<PA: PatchworkState>(p: Packet, conn_id: Uuid, patchwork_state: PA) {
+    match p {
+        Packet::ChatMessage(chat_message) => {
+            trace!(
+                "Received chat message {:?} from {:?}",
+                chat_message.message,
+                conn_id
+            );
+            let mut token_stream = chat_message.message.as_str().split(" ");
+            match token_stream.next() {
+                Some("/connect") => {
+                    connect(&mut token_stream, patchwork_state).ok();
+                }
+                _ => {}
+            }
+        }
+        _ => {
+            panic!("Chat Message Router received unexpected packet {:?}", p);
+        }
+    }
+}
+
+fn connect<'a, I: Iterator<Item = &'a str>, PA: PatchworkState>(
+    token_stream: &mut I,
+    patchwork_state: PA,
+) -> Result<(), ()> {
+    let addr = token_stream.next().ok_or(())?;
+    let port_str = token_stream.next().ok_or(())?;
+    let port = port_str.parse::<u16>().map_err(|_| ())?;
+
+    patchwork_state.new_map(Peer {
+        port: port,
+        address: String::from(addr),
+    });
+
+    Ok(())
+}

--- a/src/packet_handlers/gameplay_router.rs
+++ b/src/packet_handlers/gameplay_router.rs
@@ -1,8 +1,15 @@
+use super::chat_message_router;
+use super::interfaces::patchwork::PatchworkState;
 use super::interfaces::player::{Angle, PlayerState, Position};
 use super::packet::Packet;
 use uuid::Uuid;
 
-pub fn route_packet<P: PlayerState>(p: Packet, conn_id: Uuid, player_state: P) {
+pub fn route_packet<P: PlayerState, PA: PatchworkState>(
+    p: Packet,
+    conn_id: Uuid,
+    player_state: P,
+    patchwork_state: PA,
+) {
     match p {
         Packet::PlayerPosition(player_position) => {
             player_state.move_and_look(
@@ -38,6 +45,9 @@ pub fn route_packet<P: PlayerState>(p: Packet, conn_id: Uuid, player_state: P) {
                     pitch: player_look.pitch,
                 }),
             );
+        }
+        Packet::ChatMessage(_) => {
+            chat_message_router::route_packet(p, conn_id, patchwork_state);
         }
         Packet::Unknown => (),
         _ => {

--- a/src/services/player.rs
+++ b/src/services/player.rs
@@ -1,5 +1,6 @@
 use super::constants::SERVER_MAX_CAPACITY;
 use super::interfaces::messenger::{Messenger, SubscriberType};
+
 use super::interfaces::player::{Angle, Operations, Player, Position};
 use super::minecraft_types;
 use super::minecraft_types::float_to_angle;


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/121

### Why
Connecting to a peer was only hardcoded before. We want it to be dynamic.

### What
Added in a new packet router exclusively to deal with chat messages. Should be easy to extend it to include more utilities as we think of them.

You can type `/connect localhost 8602` to connect to the map at localhost:8602.

There's a huge problem I ran into: https://github.com/DuncanUszkay1/Patchwork/issues/141. It means that we have only 5 chunk pillars that we can convince the client to actually render. More information in that ticket.

As a result I had to rework the patchwork module to just pull from a list of positions that currently work and crash once it runs out. That's currently exactly three positions including the one you spawn on. Once I add translation for the Z axis, there will be 5. This needs to be fixed. I'm going to work on it for the rest of the sprint

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
