### PR TITLE
Tests skeleton

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -171,9 +171,9 @@ mod tests {
 
         std::thread::spawn(move || {
             server::listen(
-            inbound_packet_processor.sender(),
-            connection_service.sender(),
-            messenger.sender(),
+                inbound_packet_processor.sender(),
+                connection_service.sender(),
+                messenger.sender(),
             );
         });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,7 @@ fn main() {
         (
             module: services::messenger::start,
             name: messenger,
-            dependencies: [],
-            extras: [None]
+            dependencies: []
         ),
         (
             module: services::packet_processor::start_inbound,
@@ -121,9 +120,6 @@ mod tests {
         let (router_sender, router_receiver) = std::sync::mpsc::channel();
         let optional_router_sender = Some(router_sender.clone());
 
-        let (messenger_sender, messenger_receiver) = std::sync::mpsc::channel();
-        let optional_messenger_sender = Some(messenger_sender.clone());
-
         define_services!(
             (
                 module: services::player::start,
@@ -143,8 +139,7 @@ mod tests {
             (
                 module: services::messenger::start,
                 name: messenger,
-                dependencies: [],
-                extras: [optional_messenger_sender]
+                dependencies: []
             ),
             (
                 module: services::packet_processor::start_inbound,

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,6 @@ fn main() {
 
     SimpleLogger::init(level, logger_config).unwrap();
 
-    //trace_macros!(true);
     define_services!(
         (
             module: services::player::start,
@@ -81,7 +80,6 @@ fn main() {
             dependencies: [messenger]
         )
     );
-    //trace_macros!(false);
 
     trace!("Services Started");
 
@@ -126,7 +124,6 @@ mod tests {
         let (messenger_sender, messenger_receiver) = std::sync::mpsc::channel();
         let optional_messenger_sender = Some(messenger_sender.clone());
 
-        //trace_macros!(true);
         define_services!(
             (
                 module: services::player::start,
@@ -166,7 +163,6 @@ mod tests {
                 dependencies: [messenger]
             )
         );
-        //trace_macros!(false);
         trace!("Services Started");
 
         // the stuff below this should also probably be moved to a service model

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,3 +96,169 @@ fn main() {
         messenger.sender(),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::interfaces::connection::ConnectionService;
+    use crate::interfaces::messenger::Messenger;
+    use crate::interfaces::packet_processor::PacketProcessor;
+    use crate::models::minecraft_protocol::MinecraftProtocolReader;
+    use crate::*;
+
+    fn start_trace() {
+        let logger_config = ConfigBuilder::new()
+            .set_max_level(LevelFilter::Off)
+            .set_thread_level(LevelFilter::Off)
+            .set_target_level(LevelFilter::Off)
+            .build();
+        SimpleLogger::init(LevelFilter::Trace, logger_config).unwrap();
+    }
+
+    fn handle_connection<M: Messenger, PP: PacketProcessor, F: Fn()>(
+        mut stream: std::net::TcpStream,
+        inbound_packet_processor: PP,
+        messenger: M,
+        id: uuid::Uuid,
+        on_closure: F,
+        sx: std::sync::mpsc::Sender<i32>,
+    ) {
+        let stream_clone = stream.try_clone().expect("Failed to clone stream");
+        messenger.new_connection(id, stream_clone);
+        loop {
+            match stream.try_read_var_int() {
+                Ok(length) => {
+                    sx.send(length).expect("Failed to send data to channel");
+                }
+                Err(e) => {
+                    match e.kind() {
+                        std::io::ErrorKind::UnexpectedEof => on_closure(),
+                        std::io::ErrorKind::ConnectionReset => on_closure(),
+                        _ => {
+                            panic!("Connection closed due to {:?}", e);
+                        }
+                    };
+                    break;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test() {
+        start_trace();
+
+        define_services!(
+            (
+                module: services::player::start,
+                name: player_state,
+                dependencies: [messenger]
+            ),
+            (
+                module: services::block::start,
+                name: block_state,
+                dependencies: [messenger]
+            ),
+            (
+                module: services::patchwork::start,
+                name: patchwork_state,
+                dependencies: [messenger, inbound_packet_processor, player_state]
+            ),
+            (
+                module: services::messenger::start,
+                name: messenger,
+                dependencies: []
+            ),
+            (
+                module: services::packet_processor::start_inbound,
+                name: inbound_packet_processor,
+                dependencies: [messenger, player_state, block_state, patchwork_state]
+            ),
+            (
+                module: services::connection::start,
+                name: connection_service,
+                dependencies: [messenger, player_state, patchwork_state, inbound_packet_processor]
+            ),
+            (
+                module: services::keep_alive::start,
+                name: keep_alive,
+                dependencies: [messenger]
+            )
+        );
+        trace!("Services Started");
+
+        // Temporary, maybe set them through CLI
+        std::env::set_var("PORT", "8600");
+        std::env::set_var("PEER_PORT", "8601");
+
+        let address = String::from("127.0.0.1");
+        let port = std::env::var("PORT").unwrap().parse::<u16>().unwrap();
+        let peer_port = std::env::var("PEER_PORT").unwrap().parse::<u16>().unwrap();
+
+        patchwork_state.sender().new_map(models::map::Peer {
+            port: peer_port.clone(),
+            address: address.clone(),
+        });
+
+        // Since servers handle connection in their own thread, create a channel
+        // to retrieve information
+        let (tx, rx) = std::sync::mpsc::channel();
+        let tx_clone = tx.clone();
+
+        // Start a dummy peer server (although manually, it is the same code as server::listen(),
+        // what's been added is the interaction with the channel)
+        let connection_string = format!("{}:{}", address, peer_port);
+        let connection_string_clone = connection_string.clone();
+        let ipp = inbound_packet_processor.sender().clone();
+        let ipp2 = ipp.clone();
+        let msgr = messenger.sender().clone();
+        let msgr2 = msgr.clone();
+        let ccs = connection_service.sender().clone();
+        let ccs2 = ccs.clone();
+
+        std::thread::spawn(move || {
+            let listener = std::net::TcpListener::bind(connection_string_clone.clone())
+                .expect("Failed to bind socket");
+            trace!("Listening on {:?}", connection_string_clone);
+
+            for stream in listener.incoming() {
+                let stream = stream.expect("Failed to connect to client");
+                let ipp_clone = ipp.clone();
+                let msgr_clone = msgr.clone();
+                let ccs_clone = ccs.clone();
+                let id = uuid::Uuid::new_v4();
+                let sx = tx_clone.clone();
+                thread::spawn(move || {
+                    handle_connection(
+                        stream,
+                        ipp_clone,
+                        msgr_clone,
+                        id,
+                        || ccs_clone.close(id),
+                        sx,
+                    );
+                });
+            }
+        });
+
+        // Start a proper server on its own thread
+        std::thread::spawn(move || {
+            server::listen(ipp2, ccs2, msgr2);
+        });
+
+        // Ensure some delay to let the server launch
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        match std::net::TcpStream::connect(connection_string.clone()) {
+            Ok(stream) => {
+                trace!("Connection successful to {}", connection_string);
+                let length: i32 = rx.recv().expect("Failed to receive data from channel");
+                trace!("Received packet length {}", length);
+                stream
+                    .shutdown(std::net::Shutdown::Both)
+                    .expect("Failed to shutdown connection"); // Everything went OK, close server and client
+            }
+            Err(_why) => {
+                panic!("Failed to connect to {}", connection_string);
+            }
+        }
+    }
+}

--- a/src/services/instance.rs
+++ b/src/services/instance.rs
@@ -32,15 +32,16 @@ impl<O> ServiceInstance<O> {
 // 1. Create the service instance struct (which creates a channel for you)
 // 2. Run the service event loop method with a clone of the sender of all services it depends on
 macro_rules! define_services {
-    ($( (module: $service:path, name: $service_instance:ident, dependencies: [$($dependency:ident),*])),*) => (
+    ($( (module: $service:path, name: $service_instance:ident, dependencies: [$($dependency:ident),*] $(, extras: [$($extra:ident),*])?)),*) => (
         $(let mut $service_instance = ServiceInstance::new();)*
         $(
             paste::expr! {
-                $(let [<$dependency _clone>] = $dependency.sender(););*
+                $(let [<$dependency _clone>] = $dependency.sender();)*
+                $($(let [<$extra _clone>] = $extra.clone();)*)?
                 let sender = $service_instance.sender();
                 let receiver = $service_instance.receiver();
-                thread::spawn(move || $service(receiver, sender, $({[<$dependency _clone>]}),*));
+                thread::spawn(move || $service(receiver, sender $(, {[<$dependency _clone>]})* $(, $({[<$extra _clone>]})*)? ));
             }
         )*
-    )
+    );
 }

--- a/src/services/packet_processor.rs
+++ b/src/services/packet_processor.rs
@@ -41,11 +41,10 @@ pub fn start_inbound<
 
                 // Send raw packet info if we provided a channel
                 let test_sender_clone = test_sender.clone();
-                match test_sender_clone {
-                    Some(test_sender_clone) => test_sender_clone
-                        .send((translation_data.state.clone(), packet.clone()))
-                        .expect("Failed to send packet to channel"),
-                    _ => {}
+                if let Some(test_sender_clone) = test_sender_clone {
+                    test_sender_clone
+                        .send((translation_data.state, packet.clone()))
+                        .expect("Failed to send packet to channel");
                 }
 
                 let translation_update = packet_router::route_packet(


### PR DESCRIPTION
## Tests skeleton
Issue: [Integration tests (Issue 127)](https://github.com/DuncanUszkay1/Patchwork/issues/127)

### Why <!---Short summary of issue that this pr is solving. You can just put 'see issue' if the information is in the issue-->
We are at a point of the development where we need to automate tests. The main advantage of tests over the manual integration testing would be that we can check correctness on our codes quicker (no need to launch a Minecraft client for the moment, we can manually send packages)

### What <!---Summary of whats in the PR-->
The purpose of this PR is to show how tests may be organized. We control packets with a new channel provided in unit tests. This allows us to automatically receive any packets that go through a service and manually send a packet to see how said service interact with it.
To expand these tests, we need to add parameters to the service starters and provide them using the macro in the extras field.
The difference between this PR and the previous one is that there is much less code duplication, and the only thing we need to add to test a service is extra parameters to the starter functions

### Checks
- [ x ] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [ x ] The output of cargo clippy is empty
- [ x ] I have run cargo fmt on my most recent changes
- [] I haven't read the PR template
