### PR TITLE
Added unit tests to minecraft_protocol

### DIFF
--- a/src/models/minecraft_types.rs
+++ b/src/models/minecraft_types.rs
@@ -4,7 +4,7 @@ pub fn float_to_angle(f: f32) -> u8 {
     ((f / 360.0) * 256.0) as u8
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ChunkSection {
     pub bits_per_block: u8, //always 14 until we implement palettes
     pub data_array_length: i32,


### PR DESCRIPTION
Issue: https://github.com/DuncanUszkay1/Patchwork/issues/133

### Why
These functions (read/write chunk section/varint) are all a little weird, and we've had problems with them before. These tests should help us have more confidence that they work as expected

### What
Added tests for those functions. Read/Write var int has complete unit tests, whereas read/write chunk section just checks that a write followed by a read is a no-op.

Also fixed a bug I found where a negative value would cause write_var_int to enter an infinite loop

### Checks
- ~[ ] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)~ N/A
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
