### PR TITLE
First implementation of the block breaking feature

### DIFF
--- a/src/interfaces/block.rs
+++ b/src/interfaces/block.rs
@@ -1,4 +1,25 @@
+use super::packet::{BlockChange, PlayerDigging};
+
 use std::sync::mpsc::Sender;
 use uuid::Uuid;
 
-define_interface!(BlockState, (Report, report, [conn_id: Uuid]));
+define_interface!(
+    BlockState,
+    (Report, report, [conn_id: Uuid]),
+    (
+        BreakBlockClientbound,
+        break_block_clientbound,
+        [conn_id: Uuid, block_packet: BlockChange]
+    ),
+    (
+        BreakBlockServerbound,
+        break_block_serverbound,
+        [conn_id: Uuid, block_packet: PlayerDigging]
+    )
+);
+
+#[derive(Debug, Clone)]
+pub struct Block {
+    pub conn_id: Uuid,
+    pub block_ids: Vec<i32>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn main() {
         (
             module: services::patchwork::start,
             name: patchwork_state,
-            dependencies: [messenger, inbound_packet_processor, player_state]
+            dependencies: [messenger, inbound_packet_processor, player_state, block_state]
         ),
         (
             module: services::messenger::start,

--- a/src/models/minecraft_protocol.rs
+++ b/src/models/minecraft_protocol.rs
@@ -1,6 +1,6 @@
 extern crate byteorder;
 
-use super::minecraft_types::ChunkSection;
+use super::minecraft_types::{BlockPosition, ChunkSection};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::cmp::{max, min};
 use std::io::{Error, Read, Write};
@@ -9,6 +9,7 @@ const PALETTE_SIZE: i64 = 14; // We don't define our own palette, so we just use
 
 pub trait MinecraftProtocolReader {
     fn read_unsigned_short(&mut self) -> u16;
+    fn read_unsigned_long(&mut self) -> u64;
     fn read_short(&mut self) -> i16;
     fn read_var_int(&mut self) -> i32;
     fn try_read_var_int(&mut self) -> Result<i32, Error>;
@@ -24,11 +25,13 @@ pub trait MinecraftProtocolReader {
     fn read_byte(&mut self) -> i8;
     fn read_u_byte(&mut self) -> u8;
     fn read_boolean(&mut self) -> bool;
+    fn read_position(&mut self) -> BlockPosition;
 }
 
 pub trait MinecraftProtocolWriter {
     fn write_long(&mut self, v: i64);
     fn write_unsigned_short(&mut self, v: u16);
+    fn write_unsigned_long(&mut self, v: u64);
     fn write_short(&mut self, v: i16);
     fn write_var_int(&mut self, v: i32);
     fn write_string(&mut self, v: String);
@@ -42,6 +45,7 @@ pub trait MinecraftProtocolWriter {
     fn write_byte(&mut self, v: i8);
     fn write_u_byte(&mut self, v: u8);
     fn write_boolean(&mut self, v: bool);
+    fn write_position(&mut self, v: BlockPosition);
 }
 
 impl<T: Read> MinecraftProtocolReader for T {
@@ -59,6 +63,10 @@ impl<T: Read> MinecraftProtocolReader for T {
 
     fn read_unsigned_short(&mut self) -> u16 {
         self.read_u16::<BigEndian>().unwrap()
+    }
+
+    fn read_unsigned_long(&mut self) -> u64 {
+        self.read_u64::<BigEndian>().unwrap()
     }
 
     fn read_short(&mut self) -> i16 {
@@ -127,6 +135,10 @@ impl<T: Read> MinecraftProtocolReader for T {
             }
         }
     }
+
+    fn read_position(&mut self) -> BlockPosition {
+        read_position(self)
+    }
 }
 
 impl<T: Write> MinecraftProtocolWriter for T {
@@ -140,6 +152,10 @@ impl<T: Write> MinecraftProtocolWriter for T {
 
     fn write_unsigned_short(&mut self, v: u16) {
         self.write_u16::<BigEndian>(v).unwrap()
+    }
+
+    fn write_unsigned_long(&mut self, v: u64) {
+        self.write_u64::<BigEndian>(v).unwrap();
     }
 
     fn write_short(&mut self, v: i16) {
@@ -195,6 +211,10 @@ impl<T: Write> MinecraftProtocolWriter for T {
         } else {
             self.write_u8(0).unwrap()
         }
+    }
+
+    fn write_position(&mut self, v: BlockPosition) {
+        write_position(self, v);
     }
 }
 
@@ -302,6 +322,37 @@ fn read_chunk_section<S: Read>(stream: &mut S) -> ChunkSection {
         block_ids,
         block_light: Vec::<u64>::new(),
         sky_light: Vec::<u64>::new(),
+    }
+}
+
+fn write_position<S: Write>(stream: &mut S, v: BlockPosition) {
+    println!(
+        "Write position: decoded is (x={:?},y={:?},z={:?})\n",
+        v.x, v.y, v.z
+    );
+    let mut encoded_position: u64 = u64::from(
+        ((v.x & 0x03FF_FFFF) << 38) | ((v.z & 0x03FF_FFFF) << 12) | (u32::from(v.y) & 0xFFF),
+    );
+    println!("Write position: encoded is {:?}", encoded_position);
+    stream.write_unsigned_long(encoded_position);
+}
+
+fn read_position<S: Read>(stream: &mut S) -> BlockPosition {
+    let encoded_position = stream.read_unsigned_long();
+    println!("Read position: encoded is {:?}", encoded_position);
+    let x = encoded_position >> 38;
+    let y = encoded_position & 0xFFF;
+    let z = encoded_position << 26 >> 38;
+
+    println!(
+        "Read position: decoded is (x={:?},y={:?},z={:?})\n",
+        x, y, z
+    );
+
+    BlockPosition {
+        x: (x as u32),
+        y: (y as u16),
+        z: (z as u32),
     }
 }
 

--- a/src/models/minecraft_types.rs
+++ b/src/models/minecraft_types.rs
@@ -43,3 +43,10 @@ pub struct StatusResponse {
     pub players: PingPlayersInfo,
     pub description: Description,
 }
+
+#[derive(Debug, Clone, Copy)]
+pub struct BlockPosition {
+    pub x: u32,
+    pub y: u16,
+    pub z: u32,
+}

--- a/src/models/packet.rs
+++ b/src/models/packet.rs
@@ -2,7 +2,7 @@
 //The macro is much cleaner if we allow for unused variables
 use super::constants::{CHUNK_SIZE, ENTITY_ID_BLOCK_SIZE};
 use super::minecraft_protocol::{MinecraftProtocolReader, MinecraftProtocolWriter};
-use super::minecraft_types::ChunkSection;
+use super::minecraft_types::{BlockPosition, ChunkSection};
 use super::translation::TranslationInfo;
 use std::any::type_name;
 use std::io::{Cursor, Read, Write};
@@ -195,6 +195,25 @@ packet_boilerplate!(
             (yaw, UByte),
             (pitch, UByte),
             (on_ground, Boolean)
+        ]
+    ),
+    (
+        6,
+        BlockChange, // clientbound
+        0x0b,
+        [
+            (location, BlockPosition),
+            (block_id, VarInt)
+        ]
+    ),
+    (
+        6,
+        PlayerDigging, // serverbound
+        0x18,
+        [
+            (status, VarInt),
+            (location, BlockPosition),
+            (face, Byte)
         ]
     )
 );

--- a/src/models/packet_macros.rs
+++ b/src/models/packet_macros.rs
@@ -196,6 +196,9 @@ macro_rules! mc_to_rust_datatype {
     (ChunkSection) => {
         ChunkSection
     };
+    (BlockPosition) => {
+        BlockPosition
+    };
 }
 
 macro_rules! read_packet_field {
@@ -245,6 +248,9 @@ macro_rules! read_packet_field {
     ($stream:ident, ChunkSection) => {
         $stream.read_chunk_section()
     };
+    ($stream:ident, BlockPosition) => {
+        $stream.read_position()
+    };
 }
 
 macro_rules! write_packet_field {
@@ -293,6 +299,9 @@ macro_rules! write_packet_field {
     };
     ($stream:ident, $value:expr, ChunkSection) => {
         $stream.write_chunk_section($value)
+    };
+    ($stream:ident, $value:expr, BlockPosition) => {
+        $stream.write_position($value)
     };
 }
 

--- a/src/packet_handlers/gameplay_router.rs
+++ b/src/packet_handlers/gameplay_router.rs
@@ -1,14 +1,16 @@
 use super::chat_message_router;
+use super::interfaces::block::BlockState;
 use super::interfaces::patchwork::PatchworkState;
 use super::interfaces::player::{Angle, PlayerState, Position};
 use super::packet::Packet;
 use uuid::Uuid;
 
-pub fn route_packet<P: PlayerState, PA: PatchworkState>(
+pub fn route_packet<P: PlayerState, PA: PatchworkState, B: BlockState>(
     p: Packet,
     conn_id: Uuid,
     player_state: P,
     patchwork_state: PA,
+    block_state: B,
 ) {
     match p {
         Packet::PlayerPosition(player_position) => {
@@ -48,6 +50,14 @@ pub fn route_packet<P: PlayerState, PA: PatchworkState>(
         }
         Packet::ChatMessage(_) => {
             chat_message_router::route_packet(p, conn_id, patchwork_state);
+        }
+        Packet::PlayerDigging(block_packet) => {
+            println!("PlayerDigging from gameplay_router");
+            block_state.break_block_serverbound(conn_id, block_packet);
+        }
+        Packet::BlockChange(block_packet) => {
+            println!("BlockChange from gameplay_router");
+            block_state.break_block_clientbound(conn_id, block_packet);
         }
         Packet::Unknown => (),
         _ => {

--- a/src/services/block.rs
+++ b/src/services/block.rs
@@ -1,9 +1,11 @@
+use super::interfaces::block::Block;
 use super::interfaces::block::Operations;
 use super::interfaces::messenger::Messenger;
-use super::minecraft_types::ChunkSection;
-use super::packet::{ChunkData, Packet};
+use super::minecraft_types::{BlockPosition, ChunkSection};
+use super::packet::{BlockChange, ChunkData, Packet, PlayerDigging};
 
 use std::sync::mpsc::{Receiver, Sender};
+use uuid::Uuid;
 
 // We don't really have any meaningful block state yet- it cannot be changed or be particularly
 // complicated. We can build this up later
@@ -24,38 +26,103 @@ fn fill_dummy_block_ids(ids: &mut Vec<i32>) {
     }
 }
 
-pub fn start<M: Messenger>(
+pub fn start<M: Messenger + Clone>(
     receiver: Receiver<Operations>,
     _sender: Sender<Operations>,
     messenger: M,
 ) {
+    let mut block = Block::new();
     while let Ok(msg) = receiver.recv() {
-        match msg {
-            Operations::Report(msg) => {
-                trace!("Reporting block state to {:?}", msg.conn_id);
-                //Just send a hardcoded simple chunk pillar
-                let mut block_ids = Vec::new();
-                fill_dummy_block_ids(&mut block_ids);
-                messenger.send_packet(
-                    msg.conn_id,
-                    Packet::ChunkData(ChunkData {
-                        chunk_x: 0,
-                        chunk_z: 0,
-                        full_chunk: true,
-                        primary_bit_mask: 2_i32.pow(4),
-                        size: 12291, //I just calculated the length of this hardcoded chunk section
-                        data: ChunkSection {
-                            bits_per_block: 14,
-                            data_array_length: 896,
-                            block_ids,
-                            block_light: Vec::new(),
-                            sky_light: Vec::new(),
-                        },
-                        biomes: vec![127; 256],
-                        number_of_block_entities: 0,
-                    }),
-                );
-            }
+        //Just send a hardcoded simple chunk pillar
+        println!("Block state started");
+        handle_message(msg, &mut block, messenger.clone());
+    }
+}
+
+fn handle_message<M: Messenger + Clone>(msg: Operations, block: &mut Block, messenger: M) {
+    match msg {
+        Operations::Report(msg) => {
+            trace!("Reporting block state to {:?}", msg.conn_id);
+            println!("Reporting block state to {:?}", msg.conn_id);
+
+            refresh_chunk(msg.conn_id, &mut block.block_ids, messenger);
+        }
+        Operations::BreakBlockClientbound(msg) => {
+            println!("Block broken (clientbound)");
+            block.break_block_clientbound(BlockChange {
+                location: msg.block_packet.location,
+                block_id: 0,
+            });
+            refresh_chunk(msg.conn_id, &mut block.block_ids, messenger);
+        }
+        Operations::BreakBlockServerbound(msg) => {
+            println!("Block broken (serverbound)");
+            block.break_block_serverbound(PlayerDigging {
+                status: 2,
+                location: msg.block_packet.location,
+                face: 0,
+            });
+            refresh_chunk(msg.conn_id, &mut block.block_ids, messenger);
         }
     }
+}
+
+impl Block {
+    pub fn new() -> Block {
+        let mut block_ids = Vec::new();
+        fill_dummy_block_ids(&mut block_ids);
+        Block {
+            conn_id: Uuid::new_v4(),
+            block_ids,
+        }
+    }
+    pub fn break_block_clientbound(&mut self, block_packet: BlockChange) {
+        println!("block broken (clientbound, Block method)");
+        let i = get_1d_index(block_packet.location);
+        self.block_ids[i] = 0;
+    }
+
+    pub fn break_block_serverbound(&mut self, block_packet: PlayerDigging) {
+        println!("block broken (serverbound, Block method)");
+        let i = get_1d_index(block_packet.location);
+        self.block_ids[i] = 0;
+    }
+}
+
+fn get_1d_index(pos: BlockPosition) -> usize {
+    let mut i: usize = 0;
+
+    let mut x1d: u32 = 0;
+    let mut y1d: u16 = 0;
+    let mut z1d: u32 = 0;
+    while (pos.x > x1d && pos.y > y1d && pos.z > z1d) || i < 4095 {
+        y1d += (i % 256) as u16;
+        z1d += u32::from(y1d / 16);
+        x1d += u32::from(y1d % 16);
+
+        i += 1;
+    }
+    i
+}
+
+fn refresh_chunk<M: Messenger + Clone>(conn_id: Uuid, block_ids: &mut Vec<i32>, messenger: M) {
+    messenger.send_packet(
+        conn_id,
+        Packet::ChunkData(ChunkData {
+            chunk_x: 0,
+            chunk_z: 0,
+            full_chunk: true,
+            primary_bit_mask: 1,
+            size: 12291, //I just calculated the length of this hardcoded chunk section
+            data: ChunkSection {
+                bits_per_block: 14,
+                data_array_length: 896,
+                block_ids: block_ids.to_vec(),
+                block_light: Vec::new(),
+                sky_light: Vec::new(),
+            },
+            biomes: vec![127; 256],
+            number_of_block_entities: 0,
+        }),
+    );
 }

--- a/src/services/patchwork.rs
+++ b/src/services/patchwork.rs
@@ -1,3 +1,4 @@
+use super::interfaces::block::BlockState;
 use super::interfaces::messenger::Messenger;
 use super::interfaces::packet_processor::PacketProcessor;
 use super::interfaces::patchwork::Operations;
@@ -18,12 +19,14 @@ pub fn start<
     M: 'static + Messenger + Clone + Send,
     P: PlayerState + Clone,
     PP: 'static + PacketProcessor + Clone + Send,
+    B: BlockState + Clone,
 >(
     receiver: Receiver<Operations>,
     sender: Sender<Operations>,
     messenger: M,
     inbound_packet_processor: PP,
     player_state: P,
+    block_state: B,
 ) {
     let mut patchwork = Patchwork::new();
 
@@ -73,6 +76,7 @@ pub fn start<
                             msg.conn_id,
                             player_state.clone(),
                             sender.clone(),
+                            block_state.clone(),
                         );
                     }
                 }
@@ -96,6 +100,7 @@ pub fn start<
                                     msg.conn_id,
                                     player_state.clone(),
                                     sender.clone(),
+                                    block_state.clone(),
                                 );
                                 if patchwork.maps[anchor.map_index].peer_connection.is_some() {
                                     player_state.reintroduce(msg.conn_id);


### PR DESCRIPTION
<!---The purpose of this template is to make our PRs more consistent and have them break shit less often-->
Issue: <!---Link the GH issue this relates to here. If you don't have an issue delete this but use an issue next time. They're useful for tracking work-->
https://github.com/DuncanUszkay1/Patchwork/issues/119


### Why <!---Short summary of issue that this pr is solving. You can just put 'see issue' if the information is in the issue-->
This PR aims to keep track of the changes happening on the map (still a hardcoded chunk) with a focus on block breaking.

### What <!---Summary of whats in the PR-->
I added the two packets that will be used when a block is broken as well as a block state relatively similar to the player state and patchwork state. However none of these packets are ever fired so far, I will try and correct this in further commits.

### Checks
- [x] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [x] The output of cargo clippy is empty
- [x] I have run cargo fmt on my most recent changes
- [ ] I haven't read the PR template
