### PR TITLE
tp to last position if we receive an OOB position

### DIFF
--- a/src/interfaces/player.rs
+++ b/src/interfaces/player.rs
@@ -46,7 +46,7 @@ define_interface!(
     (
         TeleportToLastValidPos,
         teleport_to_last_valid_pos,
-        [conn_id: Uuid]
+        [conn_id: Uuid, look: Option<Angle>]
     )
 );
 

--- a/src/interfaces/player.rs
+++ b/src/interfaces/player.rs
@@ -42,6 +42,11 @@ define_interface!(
         StatusResponse,
         status_response,
         [conn_id: Uuid, version: Version, description: Description]
+    ),
+    (
+        TeleportToLastValidPos,
+        teleport_to_last_valid_pos,
+        [conn_id: Uuid]
     )
 );
 

--- a/src/services/player.rs
+++ b/src/services/player.rs
@@ -203,6 +203,19 @@ fn handle_message<M: Messenger + Clone, B: BlockState + Clone, PA: PatchworkStat
             };
             messenger.send_packet(msg.conn_id, Packet::StatusResponse(status_response));
         }
+        Operations::TeleportToLastValidPos(msg) => {
+            trace!(
+                "Teleporting to last valid position for conn_id {:?}",
+                msg.conn_id
+            );
+            let player = players
+                .get(&msg.conn_id)
+                .expect("Could not teleport to valid position: player not found");
+            messenger.send_packet(
+                msg.conn_id, 
+                Packet::ClientboundPlayerPositionAndLook(player.pos_and_look_last_valid_packet())
+            );
+        }
     }
 }
 
@@ -244,6 +257,18 @@ impl Player {
             max_players: 2,
             level_type: String::from("default"),
             reduced_debug_info: false,
+        }
+    }
+
+    pub fn pos_and_look_last_valid_packet(&self) -> ClientboundPlayerPositionAndLook {
+        ClientboundPlayerPositionAndLook {
+            x: self.position.x,
+            y: self.position.y,
+            z: self.position.z,
+            yaw: self.angle.yaw,
+            pitch: self.angle.pitch,
+            flags: 0,
+            teleport_id: 0
         }
     }
 

--- a/src/services/player.rs
+++ b/src/services/player.rs
@@ -213,7 +213,7 @@ fn handle_message<M: Messenger + Clone, B: BlockState + Clone, PA: PatchworkStat
                 .expect("Could not teleport to valid position: player not found");
             messenger.send_packet(
                 msg.conn_id, 
-                Packet::ClientboundPlayerPositionAndLook(player.pos_and_look_last_valid_packet())
+                Packet::ClientboundPlayerPositionAndLook(player.pos_last_valid_packet(msg.look))
             );
         }
     }
@@ -260,13 +260,13 @@ impl Player {
         }
     }
 
-    pub fn pos_and_look_last_valid_packet(&self) -> ClientboundPlayerPositionAndLook {
+    pub fn pos_last_valid_packet(&self, look: Option<Angle>) -> ClientboundPlayerPositionAndLook {
         ClientboundPlayerPositionAndLook {
             x: self.position.x,
             y: self.position.y,
             z: self.position.z,
-            yaw: self.angle.yaw,
-            pitch: self.angle.pitch,
+            yaw: look.unwrap_or(self.angle).yaw,
+            pitch: look.unwrap_or(self.angle).pitch,
             flags: 0,
             teleport_id: 0
         }


### PR DESCRIPTION
<!---The purpose of this template is to make our PRs more consistent and have them break shit less often-->
Issue: Enforce Map Borders #143 

### Why: see issue

### What: when patchwork receives a position for which there is no map, we call playerstate to send the last position we have for the player

### Checks
- [ ] I have performed the [manual integration test](https://github.com/DuncanUszkay1/Patchwork/wiki/Manual-Integration-Testing)
- [ ] The output of cargo clippy is empty
- [ ] I have run cargo fmt on my most recent changes
- [] I haven't read the PR template
